### PR TITLE
making noise wrapper reversible

### DIFF
--- a/src/noise_interfaces/noise_process_interface.jl
+++ b/src/noise_interfaces/noise_process_interface.jl
@@ -313,7 +313,7 @@ end
   end
 end
 
-@inline function interpolate!(W::NoiseProcess,u,p,t)
+@inline function interpolate!(W::NoiseProcess,u,p,t; reverse=false)
   if sign(W.dt)*t > sign(W.dt)*W.t[end] # Steps past W
     dt = t - W.t[end]
     if isinplace(W)
@@ -346,7 +346,11 @@ end
     end
     return out1,out2
   else # Bridge
-    i = searchsortedfirst(W.t,t)
+    if reverse
+      i = searchsortedlast(W.t,t)
+    else
+      i = searchsortedfirst(W.t,t)
+    end
     if t == W.t[i]
       if isinplace(W)
         W.curW .= W.W[i]
@@ -426,7 +430,7 @@ end
   end
 end
 
-@inline function interpolate!(out1,out2,W::NoiseProcess,u,p,t)
+@inline function interpolate!(out1,out2,W::NoiseProcess,u,p,t; reverse=false)
   if sign(W.dt)*t > sign(W.dt)*W.t[end] # Steps past W
     dt = t - W.t[end]
     W.dist(W.dW,W,dt,u,p,t,W.rng)
@@ -443,7 +447,11 @@ end
       end
     end
   else # Bridge
-    i = searchsortedfirst(W.t,t)
+    if reverse
+      i = searchsortedlast(W.t,t)
+    else
+      i = searchsortedfirst(W.t,t)
+    end
     if t == W.t[i]
       out1 .= W.W[i]
       if W.Z != nothing

--- a/src/noise_interfaces/noise_process_interface.jl
+++ b/src/noise_interfaces/noise_process_interface.jl
@@ -351,7 +351,23 @@ end
     return out1,out2
   else # Bridge
     i = searchsortedfirst(W.t,t)
-    if isapprox(t, W.t[i]; rtol = 1e-8)
+    if t isa Union{Rational,Integer} && t ==  W.t[i]
+      if isinplace(W)
+        W.curW .= W.W[i]
+      else
+        W.curW = W.W[i]
+      end
+      if W.Z != nothing
+        if isinplace(W)
+          W.curZ .= W.Z[i]
+        else
+          W.curZ = W.Z[i]
+        end
+        return copy(W.curW),copy(W.curZ)
+      else
+        return copy(W.curW),nothing
+      end
+    elseif !(t isa Union{Rational,Integer}) && isapprox(t, W.t[i]; atol = 100eps(typeof(t)), rtol = 100eps(t))
       if isinplace(W)
         W.curW .= W.W[i]
       else
@@ -462,8 +478,12 @@ end
     end
   else # Bridge
     i = searchsortedfirst(W.t,t)
-
-    if isapprox(t, W.t[i]; rtol = 1e-8)
+    if t isa Union{Rational,Integer} && t ==  W.t[i]
+      out1 .= W.W[i]
+      if W.Z != nothing
+        out2 .= W.Z[i]
+      end
+    elseif !(t isa Union{Rational,Integer}) && isapprox(t, W.t[i]; atol = 100eps(typeof(t)), rtol = 100eps(t))
       out1 .= W.W[i]
       if W.Z != nothing
         out2 .= W.Z[i]

--- a/src/noise_interfaces/noise_wrapper_interface.jl
+++ b/src/noise_interfaces/noise_wrapper_interface.jl
@@ -2,12 +2,20 @@ function save_noise!(W::NoiseWrapper)
 
 end
 
-function interpolate!(W::NoiseWrapper,u,p,t)
-  W.source(u,p,t)
+function interpolate!(W::NoiseWrapper,u,p,t; reverse=false)
+  if reverse
+    interpolate!(W,u,p,t,reverse=reverse)
+  else
+    W.source(u,p,t)
+  end
 end
 
-function interpolate!(out1,out2,W::NoiseWrapper,u,p,t)
-  W.source(out1,out2,u,p,t)
+function interpolate!(out1,out2,W::NoiseWrapper,u,p,t; reverse=false)
+  if reverse
+    interpolate!(out1,out2,W.source,u,p,t,reverse=reverse)
+  else
+    W.source(out1,out2,u,p,t)
+  end
 end
 
 function calculate_step!(W::NoiseWrapper,dt,u,p)

--- a/src/types.jl
+++ b/src/types.jl
@@ -145,22 +145,30 @@ mutable struct NoiseWrapper{T,N,Tt,T2,T3,T4,ZType,inplace} <: AbstractNoiseProce
   dZ::T3
   source::T4
   reset::Bool
+  reverse::Bool
 end
 
 function NoiseWrapper(source::AbstractNoiseProcess{T,N,Vector{T2},inplace};
-                      reset=true) where {T,N,T2,inplace}
+                      reset=true,reverse=false) where {T,N,T2,inplace}
+
+  if reverse
+    indx = length(source.t)
+  else
+    indx = 1
+  end
   if source.Z==nothing
     Z=nothing
     curZ = nothing
     dZ = nothing
   else
-    Z=[copy(source.Z[1])]
-    curZ = copy(source.Z[1])
-    dZ = copy(source.Z[1])
+    Z=[copy(source.Z[indx])]
+    curZ = copy(source.Z[indx])
+    dZ = copy(source.Z[indx])
   end
-  W = [copy(source.W[1])]
+  W = [copy(source.W[indx])]
+  
   NoiseWrapper{T,N,typeof(source.t[1]),typeof(source.W[1]),typeof(dZ),typeof(source),typeof(Z),inplace}(
-                [source.t[1]],W,W,Z,source.t[1],copy(source.W[1]),curZ,source.t[1],copy(source.W[1]),dZ,source,reset)
+                [source.t[indx]],W,W,Z,source.t[indx],copy(source.W[indx]),curZ,source.t[indx],copy(source.W[indx]),dZ,source,reset,reverse)
 end
 
 (W::NoiseWrapper)(t) = interpolate!(W,nothing,nothing,t)

--- a/src/types.jl
+++ b/src/types.jl
@@ -166,14 +166,14 @@ function NoiseWrapper(source::AbstractNoiseProcess{T,N,Vector{T2},inplace};
     dZ = copy(source.Z[indx])
   end
   W = [copy(source.W[indx])]
-  
+
   NoiseWrapper{T,N,typeof(source.t[1]),typeof(source.W[1]),typeof(dZ),typeof(source),typeof(Z),inplace}(
                 [source.t[indx]],W,W,Z,source.t[indx],copy(source.W[indx]),curZ,source.t[indx],copy(source.W[indx]),dZ,source,reset,reverse)
 end
 
 (W::NoiseWrapper)(t) = interpolate!(W,nothing,nothing,t)
 (W::NoiseWrapper)(u,p,t) = interpolate!(W,u,p,t)
-(W::NoiseWrapper)(out1,out2,u,p,t) = interpolate!(out1,out2,W,u,p,t)
+(W::NoiseWrapper)(out1,out2,u,p,t) = interpolate!(out1,out2,W,u,p,t,reverse=W.reverse)
 adaptive_alg(W::NoiseWrapper) = adaptive_alg(W.source)
 
 mutable struct NoiseFunction{T,N,wType,zType,Tt,T2,T3,inplace} <: AbstractNoiseProcess{T,N,nothing,inplace}

--- a/test/reversal_test.jl
+++ b/test/reversal_test.jl
@@ -2,15 +2,120 @@ using StochasticDiffEq, DiffEqNoiseProcess, Test, Random
 Random.seed!(100)
 α=1
 β=1
+
+dt = 1e-3
+tspan = (0.0,1.0)
 u₀=1/2
+
+f!(du,u,p,t) = du .= α*u
+g!(du,u,p,t) = du .= β*u
+
+
+prob = SDEProblem(f!,g!,[u₀],tspan)
+sol =solve(prob,EulerHeun(),dt=dt,save_noise=true)
+
+_sol = deepcopy(sol) # to make sure the plot is correct
+W1 = NoiseGrid(reverse!(_sol.t),reverse!(_sol.W.W))
+prob1 = SDEProblem(f!,g!,sol[end],reverse(tspan),noise=W1)
+sol1 = solve(prob1,EulerHeun(),dt=dt)
+
+_sol = deepcopy(sol)
+W2 = NoiseWrapper(_sol.W, reverse=true)
+prob2 = SDEProblem(f!,g!,sol[end],reverse(tspan),noise=W2)
+sol2 = solve(prob2,EulerHeun(),dt=dt)
+
+@test sol.u ≈ reverse(sol1.u) atol=1e-2
+@test sol.u ≈ reverse(sol2.u) atol=1e-2
+@test sol1.u ≈ sol2.u atol=1e-5
+
+# diagonal noise
+
+prob = SDEProblem(f!,g!,[u₀,u₀],tspan)
+sol = solve(prob,EulerHeun(),dt=dt,save_noise=true)
+
+_sol = deepcopy(sol) # to make sure the plot is correct
+W1 = NoiseGrid(reverse!(_sol.t),reverse!(_sol.W.W))
+prob1 = SDEProblem(f!,g!,sol[end],reverse(tspan),noise=W1)
+sol1 = solve(prob1,EulerHeun(),dt=dt)
+
+_sol = deepcopy(sol)
+W2 = NoiseWrapper(_sol.W, reverse=true)
+prob2 = SDEProblem(f!,g!,sol[end],reverse(tspan),noise=W2)
+sol2 = solve(prob2,EulerHeun(),dt=dt)
+
+@test sol.u ≈ reverse(sol1.u) atol=1e-1
+@test sol.u ≈ reverse(sol2.u) atol=1e-1
+@test sol1.u ≈ sol2.u atol=1e-5
+
+
+# non-diagonal noise
+
+function gnd!(du,u,p,t)
+  du[1,1] = 0.3u[1]
+  du[1,2] = 0.6u[1]
+  du[1,3] = 0.9u[1]
+  du[1,4] = 0.12u[2]
+  du[2,1] = 1.2u[1]
+  du[2,2] = 0.2u[2]
+  du[2,3] = 0.3u[2]
+  du[2,4] = 1.8u[2]
+end
+prob = SDEProblem(f!,gnd!,[u₀,u₀],tspan,noise_rate_prototype=zeros(2,4))
+sol = solve(prob,EulerHeun(),dt=dt,save_noise=true)
+
+_sol = deepcopy(sol) # to make sure the plot is correct
+W1 = NoiseGrid(reverse!(_sol.t),reverse!(_sol.W.W))
+prob1 = SDEProblem(f!,gnd!,sol[end],reverse(tspan),noise=W1,noise_rate_prototype=zeros(2,4))
+sol1 = solve(prob1,EulerHeun(),dt=dt)
+
+_sol = deepcopy(sol)
+W2 = NoiseWrapper(_sol.W, reverse=true)
+prob2 = SDEProblem(f!,gnd!,sol[end],reverse(tspan),noise=W2, noise_rate_prototype=zeros(2,4))
+sol2 = solve(prob2,EulerHeun(),dt=dt)
+
+@test sol.u ≈ reverse(sol1.u) atol=2e-1
+@test sol.u ≈ reverse(sol2.u) atol=2e-1
+@test sol1.u ≈ sol2.u atol=1e-5
+
+###
+### OOP
+###
+
 f(u,p,t) = α*u
 g(u,p,t) = β*u
-dt = 1//2^(4)
-tspan = (0.0,1.0)
-prob = SDEProblem(f,g,u₀,(0.0,1.0))
-sol =solve(prob,EulerHeun(),dt=0.001,save_noise=true)
+
+prob = SDEProblem(f,g,u₀,tspan)
+sol =solve(prob,EulerHeun(),dt=dt,save_noise=true)
+
 _sol = deepcopy(sol) # to make sure the plot is correct
-W3 = NoiseGrid(reverse!(_sol.t),reverse!(_sol.W))
-prob3 = SDEProblem(f,g,sol[end],(1.0,0.0),noise=W3)
-sol2 = solve(prob3,EulerHeun(),dt=0.001)
-@test sol.u ≈ reverse!(sol2.u) atol=1e-1
+W1 = NoiseGrid(reverse!(_sol.t),reverse!(_sol.W.W))
+prob1 = SDEProblem(f,g,sol[end],reverse(tspan),noise=W1)
+sol1 = solve(prob1,EulerHeun(),dt=dt)
+
+_sol = deepcopy(sol)
+W2 = NoiseWrapper(_sol.W, reverse=true)
+prob2 = SDEProblem(f,g,sol[end],reverse(tspan),noise=W2)
+sol2 = solve(prob2,EulerHeun(),dt=dt)
+
+@test sol.u ≈ reverse(sol1.u) atol=1e-1
+@test sol.u ≈ reverse(sol2.u) atol=1e-1
+@test sol1.u ≈ sol2.u atol=1e-5
+
+# diagonal noise
+
+prob = SDEProblem(f,g,[u₀,u₀],tspan)
+sol = solve(prob,EulerHeun(),dt=dt,save_noise=true)
+
+_sol = deepcopy(sol) # to make sure the plot is correct
+W1 = NoiseGrid(reverse!(_sol.t),reverse!(_sol.W.W))
+prob1 = SDEProblem(f,g,sol[end],reverse(tspan),noise=W1)
+sol1 = solve(prob1,EulerHeun(),dt=dt)
+
+_sol = deepcopy(sol)
+W2 = NoiseWrapper(_sol.W, reverse=true)
+prob2 = SDEProblem(f,g,sol[end],reverse(tspan),noise=W2)
+sol2 = solve(prob2,EulerHeun(),dt=dt)
+
+@test sol.u ≈ reverse(sol1.u) atol=1e-1
+@test sol.u ≈ reverse(sol2.u) atol=1e-1
+@test sol1.u ≈ sol2.u atol=1e-5

--- a/test/reversal_test.jl
+++ b/test/reversal_test.jl
@@ -1,3 +1,5 @@
+@testset "SDE Reversal Tests" begin
+
 using StochasticDiffEq, DiffEqNoiseProcess, Test, Random
 Random.seed!(100)
 α=1.01
@@ -139,3 +141,5 @@ sol2 = solve(prob2,EulerHeun(),dt=dt)
 @test sol.u ≈ reverse(sol1.u) atol=5e-2
 @test sol.u ≈ reverse(sol2.u) atol=5e-2
 @test sol1.u ≈ sol2.u atol=1e-5
+
+end

--- a/test/reversal_test.jl
+++ b/test/reversal_test.jl
@@ -1,9 +1,9 @@
 using StochasticDiffEq, DiffEqNoiseProcess, Test, Random
 Random.seed!(100)
-α=1
-β=1
+α=1.01
+β=0.87
 
-dt = 1e-3
+dt = 1e-4
 tspan = (0.0,1.0)
 u₀=1/2
 
@@ -24,9 +24,17 @@ W2 = NoiseWrapper(_sol.W, reverse=true)
 prob2 = SDEProblem(f!,g!,sol[end],reverse(tspan),noise=W2)
 sol2 = solve(prob2,EulerHeun(),dt=dt)
 
-@test sol.u ≈ reverse(sol1.u) atol=1e-2
-@test sol.u ≈ reverse(sol2.u) atol=1e-2
-@test sol1.u ≈ sol2.u atol=1e-5
+
+
+@test sol.u ≈ reverse(sol1.u) rtol=1e-2
+@test sol.u ≈ reverse(sol2.u) rtol=1e-2
+@test sol1.u ≈ sol2.u rtol=1e-6
+
+# using Plots
+# diff = [s[1] for s in sol.u-reverse(sol2.u)]
+# diffrev = [s[1] for s in sol1.u-sol2.u]
+# plot(sol.t, diff)
+# plot(sol2.t, diffrev)
 
 # diagonal noise
 


### PR DESCRIPTION
I added an option "reverse" to `NoiseWrapper` that allows us to change indexing if a reverse time evolution should be computed.

https://github.com/SciML/DiffEqNoiseProcess.jl/issues/50
https://github.com/SciML/DiffEqSensitivity.jl/issues/253

What is a bit odd is that the difference between forward and backward pass is not very good (~ 1e-1). The uploaded figure shows the difference between `sol` (forward) and `sol1` (`NoiseGrid`) for the first test. `NoiseGrid` and `NoiseWrapper` nearly coincide (1e-5).

[error.pdf](https://github.com/SciML/DiffEqNoiseProcess.jl/files/4682371/error.pdf)
