### PR TITLE
Generalization of second noise process for different sizes

### DIFF
--- a/src/compoundpoisson.jl
+++ b/src/compoundpoisson.jl
@@ -1,7 +1,7 @@
 # https://www.math.wisc.edu/~anderson/papers/AndPostleap.pdf
 # Incorporating postleap checks in tau-leaping
 # J. Chem. Phys. 128, 054103 (2008); https://doi.org/10.1063/1.2819665
-function cpp_bridge(cpp,W,W0,Wh,q,h,u,p,t,rng)
+function cpp_bridge(dW,cpp,W,W0,Wh,q,h,u,p,t,rng)
   rand.(rng,Distributions.Binomial.(Int.(Wh),float.(q)))
 end
 function cpp_bridge!(rand_vec,cpp,W,W0,Wh,q,h,u,p,t,rng)
@@ -14,10 +14,10 @@ mutable struct CompoundPoissonProcess{R,CR}
   computerates::Bool
   function CompoundPoissonProcess(rate,t0,W0;computerates=true,kwargs...)
     cpp = new{typeof(rate),typeof(W0)}(rate,W0,computerates)
-    NoiseProcess{false}(t0,W0,nothing,cpp,(W,W0,Wh,q,h,u,p,t,rng)->cpp_bridge(cpp,W,W0,Wh,q,h,u,p,t,rng);continuous=false,cache=cpp,kwargs...)
+    NoiseProcess{false}(t0,W0,nothing,cpp,(dW,W,W0,Wh,q,h,u,p,t,rng)->cpp_bridge(dW,cpp,W,W0,Wh,q,h,u,p,t,rng);continuous=false,cache=cpp,kwargs...)
   end
 end
-function (P::CompoundPoissonProcess)(W,dt,u,p,t,rng)
+function (P::CompoundPoissonProcess)(dW,W,dt,u,p,t,rng)
   P.computerates && (P.currate = P.rate(u,p,t))
   PoissonRandom.pois_rand.(rng,dt.*P.currate)
 end

--- a/src/noise_interfaces/noise_process_interface.jl
+++ b/src/noise_interfaces/noise_process_interface.jl
@@ -147,7 +147,7 @@ end
       else
         W.dWtilde = W.dist(W,dtleft,u,p,W.curt,W.rng)
         if W.Z != nothing
-          W.dZtilde = W.dist(W,dtleft,u,p,W.curt,W.rng)
+          W.dZtilde = W.dist(W.dZ,W,dtleft,u,p,W.curt,W.rng)
         end
       end
       if isinplace(W)
@@ -181,7 +181,7 @@ end
   else
     W.dW = W.dist(W,dt,u,p,W.curt,W.rng)
     if W.Z != nothing
-      W.dZ = W.dist(W,dt,u,p,W.curt,W.rng)
+      W.dZ = W.dist(W.dZ,W,dt,u,p,W.curt,W.rng)
     end
   end
   W.dt = dt
@@ -198,7 +198,7 @@ end
     else
       W.dWtilde = W.bridge(W,0,W.dW,q,dtnew,u,p,W.curt,W.rng)
       if W.Z != nothing
-        W.dZtilde=  W.bridge(W,0,W.dZ,q,dtnew,u,p,W.curt,W.rng)
+        W.dZtilde=  W.bridge(W.dZ,W,0,W.dZ,q,dtnew,u,p,W.curt,W.rng)
       end
     end
     cutLength = W.dt-dtnew
@@ -331,7 +331,7 @@ end
       W.dW = W.dist(W,dt,u,p,t,W.rng)
       W.curW += W.dW
       if W.Z != nothing
-        W.dZ = W.dist(W,dt,u,p,t,W.rng)
+        W.dZ = W.dist(W.dZ,W,dt,u,p,t,W.rng)
         W.curZ += W.dZ
       end
     end

--- a/src/noise_interfaces/noise_process_interface.jl
+++ b/src/noise_interfaces/noise_process_interface.jl
@@ -147,7 +147,11 @@ end
       else
         W.dWtilde = W.dist(W,dtleft,u,p,W.curt,W.rng)
         if W.Z != nothing
-          W.dZtilde = W.dist(W.dZ,W,dtleft,u,p,W.curt,W.rng)
+          if size(W.dZ) != size(W.dW)
+            W.dZtilde = W.dist(W.dZ,W,dtleft,u,p,W.curt,W.rng)
+          else
+            W.dZtilde = W.dist(W,dtleft,u,p,W.curt,W.rng)
+          end
         end
       end
       if isinplace(W)
@@ -181,7 +185,11 @@ end
   else
     W.dW = W.dist(W,dt,u,p,W.curt,W.rng)
     if W.Z != nothing
-      W.dZ = W.dist(W.dZ,W,dt,u,p,W.curt,W.rng)
+      if size(W.dZ) != size(W.dW)
+        W.dZ = W.dist(W.dZ,W,dt,u,p,W.curt,W.rng)
+      else
+        W.dZ = W.dist(W,dt,u,p,W.curt,W.rng)
+      end
     end
   end
   W.dt = dt

--- a/src/noise_interfaces/noise_process_interface.jl
+++ b/src/noise_interfaces/noise_process_interface.jl
@@ -92,9 +92,9 @@ end
             W.bridge(W.dZtilde,W,W.curZ,L₃,qtmp,L₁,u,p,W.curt,W.rng)
           end
         else
-          W.dWtilde = W.bridge(W,W.curW,L₂,qtmp,L₁,u,p,W.curt,W.rng)
+          W.dWtilde = W.bridge(W.dW,W,W.curW,L₂,qtmp,L₁,u,p,W.curt,W.rng)
           if W.Z != nothing
-            W.dZtilde = W.bridge(W,W.curZ,L₃,qtmp,L₁,u,p,W.curt,W.rng)
+            W.dZtilde = W.bridge(W.dZ,W,W.curZ,L₃,qtmp,L₁,u,p,W.curt,W.rng)
           end
         end
         if isinplace(W)
@@ -145,13 +145,9 @@ end
           W.dist(W.dZtilde,W,dtleft,u,p,W.curt,W.rng)
         end
       else
-        W.dWtilde = W.dist(W,dtleft,u,p,W.curt,W.rng)
+        W.dWtilde = W.dist(W.dW,W,dtleft,u,p,W.curt,W.rng)
         if W.Z != nothing
-          if size(W.dZ) != size(W.dW)
-            W.dZtilde = W.dist(W.dZ,W,dtleft,u,p,W.curt,W.rng)
-          else
-            W.dZtilde = W.dist(W,dtleft,u,p,W.curt,W.rng)
-          end
+          W.dZtilde = W.dist(W.dZ,W,dtleft,u,p,W.curt,W.rng)
         end
       end
       if isinplace(W)
@@ -183,13 +179,9 @@ end
       W.dist(W.dZ,W,dt,u,p,W.curt,W.rng)
     end
   else
-    W.dW = W.dist(W,dt,u,p,W.curt,W.rng)
+    W.dW = W.dist(W.dW,W,dt,u,p,W.curt,W.rng)
     if W.Z != nothing
-      if size(W.dZ) != size(W.dW)
-        W.dZ = W.dist(W.dZ,W,dt,u,p,W.curt,W.rng)
-      else
-        W.dZ = W.dist(W,dt,u,p,W.curt,W.rng)
-      end
+      W.dZ = W.dist(W.dZ,W,dt,u,p,W.curt,W.rng)
     end
   end
   W.dt = dt
@@ -204,7 +196,7 @@ end
         W.bridge(W.dZtilde,W,0,W.dZ,q,dtnew,u,p,W.curt,W.rng)
       end
     else
-      W.dWtilde = W.bridge(W,0,W.dW,q,dtnew,u,p,W.curt,W.rng)
+      W.dWtilde = W.bridge(W.dW,W,0,W.dW,q,dtnew,u,p,W.curt,W.rng)
       if W.Z != nothing
         W.dZtilde=  W.bridge(W.dZ,W,0,W.dZ,q,dtnew,u,p,W.curt,W.rng)
       end
@@ -289,9 +281,9 @@ end
         #W.dZtilde .-= W.curZ
       end
     else
-      W.dWtilde = W.bridge(W,0,W.dWtmp,qK,dtK,u,p,W.curt,W.rng)# - W.curW
+      W.dWtilde = W.bridge(W.dW,W,0,W.dWtmp,qK,dtK,u,p,W.curt,W.rng)# - W.curW
       if W.Z != nothing
-        W.dZtilde = W.bridge(W,0,W.dZtmp,qK,dtK,u,p,W.curt,W.rng)# - W.curZ
+        W.dZtilde = W.bridge(W.dZ,W,0,W.dZtmp,qK,dtK,u,p,W.curt,W.rng)# - W.curZ
       end
     end
     # This is a control variable so do not diff through it
@@ -336,7 +328,7 @@ end
         W.curZ .+= W.dZ
       end
     else
-      W.dW = W.dist(W,dt,u,p,t,W.rng)
+      W.dW = W.dist(W.dW,W,dt,u,p,t,W.rng)
       W.curW += W.dW
       if W.Z != nothing
         W.dZ = W.dist(W.dZ,W,dt,u,p,t,W.rng)
@@ -428,7 +420,7 @@ end
           new_curZ = nothing
         end
       else
-        new_curW = W.bridge(W,W0,Wh,q,h,u,p,t,W.rng)
+        new_curW = W.bridge(W.dW,W,W0,Wh,q,h,u,p,t,W.rng)
         if iscontinuous(W)
           # This should actually be based on the function for computing the mean
           # flow of the noise process, but for now we'll just handle Wiener and
@@ -438,7 +430,7 @@ end
           new_curW += W0
         end
         if W.Z != nothing
-          new_curZ = W.bridge(W,Z0,Zh,q,h,u,p,t,W.rng)
+          new_curZ = W.bridge(W.dZ,W,Z0,Zh,q,h,u,p,t,W.rng)
           if iscontinuous(W)
             new_curZ += (1-q)*Z0
           else

--- a/src/ornstein_uhlenbeck.jl
+++ b/src/ornstein_uhlenbeck.jl
@@ -4,11 +4,11 @@ struct OrnsteinUhlenbeck{T1,T2,T3}
   σ::T3
 end
 # http://www.math.ku.dk/~susanne/StatDiff/Overheads1b.pdf
-function (X::OrnsteinUhlenbeck)(W,dt,u,p,t,rng) #dist
-  if typeof(W.dW) <: AbstractArray
-    rand_val = wiener_randn(rng,W.dW)
+function (X::OrnsteinUhlenbeck)(dW,W,dt,u,p,t,rng) #dist
+  if typeof(dW) <: AbstractArray
+    rand_val = wiener_randn(rng,dW)
   else
-    rand_val = wiener_randn(rng,typeof(W.dW))
+    rand_val = wiener_randn(rng,typeof(dW))
   end
   drift = X.μ .+ (W[end] .- X.μ) .* exp.(-X.Θ*dt)
   diffusion = X.σ .* sqrt.((1 .- exp.(-2X.Θ*dt))./(2X.Θ))
@@ -26,12 +26,12 @@ q = -Θ
 r = Θμ
 https://arxiv.org/pdf/1011.0067.pdf page 18
 =#
-function ou_bridge(ou,W,W0,Wh,q,hu,p,t,rng) end
+function ou_bridge(dW,ou,W,W0,Wh,q,hu,p,t,rng) end
 function ou_bridge!(rand_vec,ou,W,W0,Wh,q,h,u,p,t,rng) end
 
 function OrnsteinUhlenbeckProcess(Θ,μ,σ,t0,W0,Z0=nothing;kwargs...)
   ou = OrnsteinUhlenbeck(Θ,μ,σ)
-  NoiseProcess(t0,W0,Z0,ou,nothing;kwargs...)
+  NoiseProcess{false}(t0,W0,Z0,ou,nothing;kwargs...)
 end
 
 struct OrnsteinUhlenbeck!{T1,T2,T3}
@@ -46,5 +46,5 @@ function (X::OrnsteinUhlenbeck!)(rand_vec,W,dt,u,p,t,rng) #dist!
 end
 function OrnsteinUhlenbeckProcess!(Θ,μ,σ,t0,W0,Z0=nothing;kwargs...)
   ou = OrnsteinUhlenbeck!(Θ,μ,σ)
-  NoiseProcess(t0,W0,Z0,ou,nothing;kwargs...)
+  NoiseProcess{true}(t0,W0,Z0,ou,nothing;kwargs...)
 end

--- a/src/wiener.jl
+++ b/src/wiener.jl
@@ -27,14 +27,30 @@ end
   end
 end
 
+@inline function WHITE_NOISE_DIST(dW,W,dt,u,p,t,rng)
+  if typeof(dW) <: AbstractArray && !(typeof(dW) <: SArray)
+    return @fastmath sqrt(abs(dt))*wiener_randn(rng,dW)
+  else
+    return @fastmath sqrt(abs(dt))*wiener_randn(rng,typeof(dW))
+  end
+end
+
 function WHITE_NOISE_BRIDGE(W,W0,Wh,q,h,u,p,t,rng)
   if typeof(W.dW) <: AbstractArray
     return @fastmath sqrt((1-q)*q*abs(h))*wiener_randn(rng,W.dW)+q*Wh
   else
     return @fastmath sqrt((1-q)*q*abs(h))*wiener_randn(rng,typeof(W.dW))+q*Wh
   end
-
 end
+
+function WHITE_NOISE_BRIDGE(dW,W,W0,Wh,q,h,u,p,t,rng)
+  if typeof(dW) <: AbstractArray
+    return @fastmath sqrt((1-q)*q*abs(h))*wiener_randn(rng,dW)+q*Wh
+  else
+    return @fastmath sqrt((1-q)*q*abs(h))*wiener_randn(rng,typeof(dW))+q*Wh
+  end
+end
+
 WienerProcess(t0,W0,Z0=nothing;kwargs...) = NoiseProcess{false}(t0,W0,Z0,WHITE_NOISE_DIST,WHITE_NOISE_BRIDGE;kwargs...)
 SimpleWienerProcess(t0,W0,Z0=nothing;kwargs...) = SimpleNoiseProcess{false}(t0,W0,Z0,WHITE_NOISE_DIST,WHITE_NOISE_BRIDGE;kwargs...)
 

--- a/src/wiener.jl
+++ b/src/wiener.jl
@@ -19,27 +19,11 @@ end
   end
 end
 
-@inline function WHITE_NOISE_DIST(W,dt,u,p,t,rng)
-  if typeof(W.dW) <: AbstractArray && !(typeof(W.dW) <: SArray)
-    return @fastmath sqrt(abs(dt))*wiener_randn(rng,W.dW)
-  else
-    return @fastmath sqrt(abs(dt))*wiener_randn(rng,typeof(W.dW))
-  end
-end
-
 @inline function WHITE_NOISE_DIST(dW,W,dt,u,p,t,rng)
   if typeof(dW) <: AbstractArray && !(typeof(dW) <: SArray)
     return @fastmath sqrt(abs(dt))*wiener_randn(rng,dW)
   else
     return @fastmath sqrt(abs(dt))*wiener_randn(rng,typeof(dW))
-  end
-end
-
-function WHITE_NOISE_BRIDGE(W,W0,Wh,q,h,u,p,t,rng)
-  if typeof(W.dW) <: AbstractArray
-    return @fastmath sqrt((1-q)*q*abs(h))*wiener_randn(rng,W.dW)+q*Wh
-  else
-    return @fastmath sqrt((1-q)*q*abs(h))*wiener_randn(rng,typeof(W.dW))+q*Wh
   end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,4 +17,5 @@ using Test
   include("bridge_test.jl")
   include("sde_adaptivedistribution_tests.jl")
   include("reversal_test.jl")
+  include("two_processes.jl")
 end

--- a/test/two_processes.jl
+++ b/test/two_processes.jl
@@ -1,0 +1,27 @@
+using StochasticDiffEq, DiffEqNoiseProcess, Test, LinearAlgebra
+using Random, RandomNumbers
+seed=100; Random.seed!(seed)
+@testset "Two noise processes for different m" begin
+  for m=1:4
+    rand_prototype = zeros(m)
+    rand_prototype2 = similar(rand_prototype,Int(m*(m-1)/2))
+    rand_prototype2 .= false
+    Random.seed!(seed)
+    W = WienerProcess!(0.0,rand_prototype,rand_prototype2,
+                     save_everystep=true,
+                     rng = Xorshifts.Xoroshiro128Plus(seed))
+    prob = NoiseProblem(W,(0.0,1.0))
+    sol = solve(prob;dt=0.2)
+
+    Random.seed!(seed)
+    Woop = WienerProcess(0.0,rand_prototype,rand_prototype2,
+                     save_everystep=true,
+                     rng = Xorshifts.Xoroshiro128Plus(seed))
+    proboop = NoiseProblem(Woop,(0.0,1.0))
+    soloop = solve(proboop;dt=0.2)
+
+    @test norm(soloop.W - sol.W) == 0.0
+    @test norm(soloop.Z - sol.Z) == 0.0
+
+  end
+end


### PR DESCRIPTION
In weak schemes like PL1WM, we would like to have different sizes of the Noise processes. While the first noise process should have the usual size of m independent Processes, the second one should have m*(m-1)/2.  

I added a dispatch for the distribution and bridges of the Wiener processes which takes dW as an input.  Thus the proper number of random variables can be drawn.