### PR TITLE
extraction tests for noise values

### DIFF
--- a/src/noise_interfaces/noise_process_interface.jl
+++ b/src/noise_interfaces/noise_process_interface.jl
@@ -354,7 +354,7 @@ end
       i = searchsortedfirst(W.t,t)
     else
       i = searchsortedfirst(W.t,t-eps(typeof(t)))
-    end  
+    end
     if t isa Union{Rational,Integer} && t ==  W.t[i]
       if isinplace(W)
         W.curW .= W.W[i]

--- a/src/noise_interfaces/noise_process_interface.jl
+++ b/src/noise_interfaces/noise_process_interface.jl
@@ -350,7 +350,7 @@ end
     end
     return out1,out2
   else # Bridge
-    i = searchsortedfirst(W.t,t)
+    i = searchsortedfirst(W.t,t-eps(typeof(t)))
     if t isa Union{Rational,Integer} && t ==  W.t[i]
       if isinplace(W)
         W.curW .= W.W[i]

--- a/src/noise_interfaces/noise_process_interface.jl
+++ b/src/noise_interfaces/noise_process_interface.jl
@@ -350,7 +350,11 @@ end
     end
     return out1,out2
   else # Bridge
-    i = searchsortedfirst(W.t,t-eps(typeof(t)))
+    if t isa Union{Rational,Integer}
+      i = searchsortedfirst(W.t,t)
+    else
+      i = searchsortedfirst(W.t,t-eps(typeof(t)))
+    end  
     if t isa Union{Rational,Integer} && t ==  W.t[i]
       if isinplace(W)
         W.curW .= W.W[i]

--- a/test/extraction_test.jl
+++ b/test/extraction_test.jl
@@ -1,0 +1,39 @@
+@testset "Noise Extraction Test" begin
+  using Random, DiffEqNoiseProcess, DiffEqBase, Test
+  seed = 100
+  Random.seed!(seed)
+
+  tstart = 0.0
+  tend = 1.0
+  dt = 0.1
+  trange = (tstart, tend)
+  t = tstart:dt:tend
+  tarray = collect(t)
+
+  W = WienerProcess(0.0,0.0,0.0)
+  prob = NoiseProblem(W,trange)
+  sol = solve(prob, dt=dt)
+
+  _sol = deepcopy(sol)
+  sol.save_everystep = false
+  for i in 1:1:length(tarray)
+    t = tarray[i]
+    sol(t)
+  end
+  @test length(_sol) == length(sol.W) == length(tarray)
+  @test _sol == sol
+
+  Random.seed!(seed)
+  W2 = WienerProcess!(0.0,[0.0],[0.0])
+  prob2 = NoiseProblem(W2,trange)
+  sol2 = solve(prob2, dt=dt)
+
+  sol2.save_everystep = false
+  for i in 1:1:length(tarray)
+    t = tarray[i]
+    sol2(t)
+  end
+
+  @test length(sol2.W) == length(tarray)
+  @test minimum(_sol .== sol2)
+end

--- a/test/extraction_test.jl
+++ b/test/extraction_test.jl
@@ -1,16 +1,14 @@
 @testset "Noise Extraction Test" begin
-
   using Random, DiffEqNoiseProcess, DiffEqBase, Test
   seed = 100
   Random.seed!(seed)
 
   tstart = 0.0
   tend = 1.0
-  dt = 0.1
+  dt = 0.001
   trange = (tstart, tend)
-  t = tstart:dt:tend
-  tarray = collect(t)
 
+  Random.seed!(seed)
   W = WienerProcess(0.0,0.0,0.0)
   prob = NoiseProblem(W,trange)
   sol = solve(prob, dt=dt)
@@ -18,9 +16,11 @@
   _sol = deepcopy(sol)
   _sol.save_everystep = false
   sol.save_everystep = false
-  for i in 1:1:length(tarray)
+  tarray = [tstart]
+  for i = 1:1000
     t = tarray[i]
     sol(t)
+    push!(tarray,t+dt)
   end
   @test length(_sol) == length(sol.W) == length(tarray)
   @test _sol == sol

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,4 +18,5 @@ using Test
   include("sde_adaptivedistribution_tests.jl")
   include("reversal_test.jl")
   include("two_processes.jl")
+  include("extraction_test.jl")
 end


### PR DESCRIPTION
This solves the issue for extracting noise values as mentioned in https://github.com/SciML/StochasticDiffEq.jl/issues/324

There seems to be no further error when t is decreased by floating point error. To keep the length of the solution object the same it is still necessary to set `save_everystep = false` before extraction.