### PR TITLE
allow noise wrapper to start at an indx different from zero

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -149,13 +149,16 @@ mutable struct NoiseWrapper{T,N,Tt,T2,T3,T4,ZType,inplace} <: AbstractNoiseProce
 end
 
 function NoiseWrapper(source::AbstractNoiseProcess{T,N,Vector{T2},inplace};
-                      reset=true,reverse=false) where {T,N,T2,inplace}
+                      reset=true,reverse=false,indx=nothing) where {T,N,T2,inplace}
 
-  if reverse
-    indx = length(source.t)
-  else
-    indx = 1
+  if indx === nothing
+    if reverse
+      indx = length(source.t)
+    else
+      indx = 1
+    end
   end
+
   if source.Z==nothing
     Z=nothing
     curZ = nothing

--- a/test/restart_test.jl
+++ b/test/restart_test.jl
@@ -1,0 +1,41 @@
+@testset "Restart" begin
+
+  using Test, LinearAlgebra
+  using StochasticDiffEq, DiffEqNoiseProcess
+  using Random
+
+  u₀ = [0.5]
+  tstart = 0.0
+  tend = 1.0
+  dt = 0.005
+  trange = (tstart, tend)
+
+  f!(du,u,p,t) = du.=1.01*u
+  σ!(du,u,p,t) = du.=0.87*u
+
+  dt1 = tend/1e3
+  seed = 100
+  Random.seed!(seed)
+  prob = SDEProblem(f!,σ!,u₀,trange)
+  sol = solve(prob,EulerHeun(),dt=dt1,adaptive=false, save_noise=true, saveat=collect(trange[1]:dt1:trange[2]))
+
+  # choose a random interval
+  interval = (0.35, 0.87)
+
+  idx1 = searchsortedfirst(sol.t, interval[1])
+  idx2 = searchsortedfirst(sol.t, interval[2])
+
+  forwardnoise = DiffEqNoiseProcess.NoiseGrid(sol.t[idx1:idx2], sol.W.W[idx1:idx2])
+  forwardnoise2 = DiffEqNoiseProcess.NoiseWrapper(sol.W, indx=idx1)
+
+  cpsol = solve(remake(prob, tspan=interval, u0=sol(interval[1]), noise=forwardnoise), sol.alg, save_noise=false; dt=dt1)
+  cpsol2 = solve(remake(prob, tspan=interval, u0=sol(interval[1]), noise=forwardnoise2), sol.alg, save_noise=false; dt=dt1)
+
+  sola = vcat(sol.u[idx1:idx2] ...)
+  cpsola = vcat(cpsol.u ...)
+  cpsol2a = vcat(cpsol2.u ...)
+
+  @test isapprox(sola, cpsola, atol=1e-10 )
+  @test isapprox(sola, cpsol2a, atol=1e-10 )
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,4 +19,5 @@ using Test
   include("reversal_test.jl")
   include("two_processes.jl")
   include("extraction_test.jl")
+  include("restart_test.jl")
 end


### PR DESCRIPTION
Adds an optional indx from which `NoiseWrapper` starts. 

This should allow us to replace `NoiseGrid` in `InterpolatingAdjoint`.
https://github.com/SciML/DiffEqSensitivity.jl/issues/253