### PR TITLE
extraction and endpoint fixes

### DIFF
--- a/src/noise_interfaces/noise_process_interface.jl
+++ b/src/noise_interfaces/noise_process_interface.jl
@@ -480,7 +480,7 @@ end
         push!(W.Z,copy(out2))
       end
     end
-    out1 .= W.curW + W.dW
+    @. out1 = W.curW + W.dW
     if W.Z != nothing
       out2 .= W.curZ + W.dZ
     end

--- a/src/noise_interfaces/noise_process_interface.jl
+++ b/src/noise_interfaces/noise_process_interface.jl
@@ -482,7 +482,7 @@ end
     end
     @. out1 = W.curW + W.dW
     if W.Z != nothing
-      out2 .= W.curZ + W.dZ
+      @. out2 = W.curZ + W.dZ
     end
   else # Bridge
     if t isa Union{Rational,Integer}

--- a/src/noise_interfaces/noise_process_interface.jl
+++ b/src/noise_interfaces/noise_process_interface.jl
@@ -480,8 +480,17 @@ end
         push!(W.Z,copy(out2))
       end
     end
+    out1 .= W.curW + W.dW
+    if W.Z != nothing
+      out2 .= W.curZ + W.dZ
+    end
   else # Bridge
-    i = searchsortedfirst(W.t,t)
+    if t isa Union{Rational,Integer}
+      i = searchsortedfirst(W.t,t)
+    else
+      i = searchsortedfirst(W.t,t-eps(typeof(t)))
+    end
+
     if t isa Union{Rational,Integer} && t ==  W.t[i]
       out1 .= W.W[i]
       if W.Z != nothing
@@ -530,6 +539,7 @@ end
       end
     end
   end
+  return nothing
 end
 
 function resize_stack!(W::NoiseProcess,i)

--- a/src/noise_interfaces/noise_process_interface.jl
+++ b/src/noise_interfaces/noise_process_interface.jl
@@ -480,10 +480,13 @@ end
         push!(W.Z,copy(out2))
       end
     end
-    @. out1 = W.curW + W.dW
-    if W.Z != nothing
-      @. out2 = W.curZ + W.dZ
-    end
+    # if abs(dt) < 1e-14
+    #   @. out1 = W.curW + W.dW
+    #   if W.Z != nothing
+    #     @. out2 = W.curZ + W.dZ
+    #   end
+    # end
+
   else # Bridge
     if t isa Union{Rational,Integer}
       i = searchsortedfirst(W.t,t)

--- a/test/noise_wrapper.jl
+++ b/test/noise_wrapper.jl
@@ -1,6 +1,6 @@
+using DiffEqNoiseProcess, Test, Random
+using StochasticDiffEq, LinearAlgebra
 @testset "NoiseWrapper" begin
-  using DiffEqNoiseProcess, Test, Random
-
   _W = WienerProcess(0.0,0.0,0.0)
 
   dt = 0.1
@@ -88,8 +88,6 @@
 end
 
 @testset "NoiseWrapper restart tests to interpolate" begin
-
-  using StochasticDiffEq, LinearAlgebra
   seed = 100
   u₀ = [0.75,0.5]
   p = [-1.5,0.05,0.2, 0.01]
@@ -177,4 +175,97 @@ end
   @test checkGrid.W.W[end] ≈ sol.W.W[end] rtol=1e-16
 
   @show checkGrid.u[end] - sol.u[end]
+end
+
+
+@testset "Interpolation with small eps jumps" begin
+  seed = 100
+  u₀ = [1.0]
+  p = [1.1,0.87]
+  trange = (0.0,1.0)
+  dtmix = trange[2]/1e4
+
+  function f!(du,u,p,t)
+    du[1] = p[1]*u[1]
+    nothing
+  end
+
+  function g!(du,u,p,t)
+    du[1] = p[2]*u[1]
+    nothing
+  end
+
+  function f(u,p,t)
+    dx = p[1]*u[1]
+    [dx]
+  end
+
+  function g(u,p,t)
+    dx = p[2]*u[1]
+    [dx]
+  end
+
+  Random.seed!(seed)
+  prob = SDEProblem(f!,g!,u₀,trange,p)
+  sol = solve(prob, EM(), dt=dtmix, save_noise=true)
+
+  Random.seed!(seed)
+  proboop = SDEProblem(f,g,u₀,trange,p)
+  soloop = solve(proboop,EM(), dt=dtmix, save_noise=true,save_end=false)
+
+  @test soloop.u ≈ sol.u
+
+  @test length(sol.u) != 1e4+1
+
+  # pl1 = using Plots; plot(sol.t[2:end]-sol.t[1:end-1], label="sol.t")
+  # pl2 = plot(sol.W.t[2:end]-sol.W.t[1:end-1], label="sol.W.t")
+  # pl3 = plot(vcat(sol.u[2:end]-sol.u[1:end-1]...), label="sol.u")
+  # pl4 = plot(log.(abs.(vcat(sol.W[2:end]-sol.W[1:end-1]...))), label="sol.W")
+
+
+  indx1 = Int(length(sol.t) - 100)
+  interval = (sol.t[indx1], sol.t[end])
+
+  #inplace
+
+  _sol = deepcopy(sol)
+  sol.W.save_everystep = false
+  _sol.W.save_everystep = false
+
+  forwardnoise = DiffEqNoiseProcess.NoiseWrapper(_sol.W, indx=indx1)
+
+  checkWrapper = solve(remake(_sol.prob, tspan=interval, u0=_sol(interval[1]), noise=forwardnoise), _sol.alg, save_noise=false; dt=abs(_sol.W.t[end-1]-_sol.W.t[end-2]-10eps(1.0)),tstops = sol.t[indx1:end])
+
+
+  @test length(checkWrapper.u) != length(sol.u)
+
+  @test checkWrapper.u[end-1] ≈ sol.u[end-1] rtol=1e-13
+  @test checkWrapper.u[end] ≈ sol.u[end] rtol=1e-13
+  @test checkWrapper.W.W[end] ≈ sol.W.W[end] rtol=1e-16
+  @test checkWrapper(sol.t[indx1:end]).u ≈ sol.u[indx1:end]  rtol=1e-14
+
+
+  # pl1 = using Plots; plot(checkWrapper.t[2:end]-checkWrapper.t[1:end-1], label="sol.t")
+  # pl2 = plot(checkWrapper.W.t[2:end]-checkWrapper.W.t[1:end-1], label="sol.W.t")
+  # pl3 = plot(vcat(checkWrapper.u[2:end]-checkWrapper.u[1:end-1]...), label="sol.u")
+  # pl4 = plot(checkWrapper.W.t[2:end], vcat(checkWrapper.W[2:end]-checkWrapper.W[1:end-1]...), label="sol.W")
+  # plot!(_sol.t[indx1+1:end], vcat(_sol.W.W[indx1+1:end]-_sol.W.W[indx1:end-1]...), label="sol.W")
+
+
+
+  _sol = deepcopy(soloop)
+  sol.W.save_everystep = false
+  _sol.W.save_everystep = false
+
+  forwardnoise = DiffEqNoiseProcess.NoiseWrapper(_sol.W, indx=indx1)
+
+  checkWrapper = solve(remake(_sol.prob, tspan=interval, u0=_sol(interval[1]), noise=forwardnoise), _sol.alg, save_noise=false; dt=abs(_sol.W.t[end-1]-_sol.W.t[end-2]-10eps(1.0)),tstops = sol.t[indx1:end])
+
+
+  @test length(checkWrapper.u) != length(soloop.u)
+
+  @test checkWrapper.u[end-1] ≈ soloop.u[end-1] rtol=1e-13
+  @test checkWrapper.u[end] ≈ soloop.u[end] rtol=1e-13
+  @test checkWrapper.W.W[end] ≈ soloop.W.W[end] rtol=1e-16
+  @test checkWrapper(soloop.t[indx1:end]).u ≈ soloop.u[indx1:end]  rtol=1e-14
 end


### PR DESCRIPTION
This seems to fix the slightly wrong gradients for `InterpolatingAdjoint` with an inplace `NoiseWrapper`

This part:
```julia
  if t isa Union{Rational,Integer}
      i = searchsortedfirst(W.t,t)
    else
      i = searchsortedfirst(W.t,t-eps(typeof(t)))
    end
```
was missing such that the correct index was not found.

This part 
```julia
 out1 .= W.curW + W.dW
    if W.Z != nothing
      out2 .= W.curZ + W.dZ
    end
```
 is necessary because by construction, `curW` is substracted from `out1` to obtain `W.dW`
https://github.com/SciML/DiffEqNoiseProcess.jl/blob/d6e1d61c4e7d162b58fd91c3c9dcafab802664a9/src/noise_interfaces/noise_wrapper_interface.jl#L24 (That was the hard one..)
