### PR TITLE
Remove DataStructures

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 version = "5.1.2"
 
 [deps]
-DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -19,7 +18,6 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-DataStructures = "0.17"
 DiffEqBase = "6.11"
 Distributions = "0.22, 0.23"
 PoissonRandom = "0.4"

--- a/src/DiffEqNoiseProcess.jl
+++ b/src/DiffEqNoiseProcess.jl
@@ -1,6 +1,6 @@
 module DiffEqNoiseProcess
 
-using DataStructures, ResettableStacks, DiffEqBase, RecipesBase
+using ResettableStacks, DiffEqBase, RecipesBase
 using RecursiveArrayTools, StaticArrays, Random, Statistics
 using LinearAlgebra, Requires
 

--- a/test/bridge_test.jl
+++ b/test/bridge_test.jl
@@ -1,6 +1,6 @@
 @testset "Brownian Bridge" begin
 
-using DiffEqNoiseProcess, DiffEqBase, Test, DataStructures, Random, DiffEqBase.EnsembleAnalysis
+using DiffEqNoiseProcess, DiffEqBase, Test, Random, DiffEqBase.EnsembleAnalysis
 
 Random.seed!(100)
 W = BrownianBridge(0.0,1.0,0.0,1.0,0.0,0.0)


### PR DESCRIPTION
Tests in OrdinaryDiffEq and other packages need a release of DiffEqNoiseProcesses that supports DataStructures 0.18 (such as https://github.com/SciML/DiffEqNoiseProcess.jl/pull/59 which however wasn't tested with 0.18). However, it seems DataStructures isn't used at all? At least tests still pass after removing DataStructures.