### PR TITLE
Ito SDE reversal

### DIFF
--- a/src/noise_interfaces/noise_grid_interface.jl
+++ b/src/noise_interfaces/noise_grid_interface.jl
@@ -48,8 +48,15 @@ function interpolate!(out1,out2,W::NoiseGrid,t)
   sign(W.dt)*t > sign(W.dt)*ts[end] && error("Solution interpolation cannot extrapolate past the final timepoint. Build a longer NoiseGrid to cover the integration.")
   sign(W.dt)*t < sign(W.dt)*ts[1] && error("Solution interpolation cannot extrapolate before the first timepoint. Build a longer NoiseGrid to cover the integration.")
   tdir = sign(ts[end]-ts[1])
-  @inbounds i = searchsortedfirst(ts,t,rev=tdir<0) # It's in the interval ts[i-1] to ts[i]
-  @inbounds if ts[i] == t
+
+
+  if t isa Union{Rational,Integer}
+    @inbounds i = searchsortedfirst(ts,t,rev=tdir<0) # It's in the interval ts[i-1] to ts[i]
+  else
+    @inbounds i = searchsortedfirst(ts,t-tdir*10eps(typeof(t)),rev=tdir<0)
+  end
+
+  @inbounds if (t isa Union{Rational,Integer} && ts[i] == t) || (isapprox(t, ts[i]; atol = 100eps(typeof(t)), rtol = 100eps(t)))
     copyto!(out1,timeseries[i])
     timeseries2 != nothing && copyto!(out2,timeseries2[i])
   elseif ts[i-1] == t # Can happen if it's the first value!

--- a/test/noise_grid.jl
+++ b/test/noise_grid.jl
@@ -37,4 +37,10 @@
   W = NoiseGrid(t,brownian_values2)
   prob = NoiseProblem(W,(0.0,1.0))
   sol = solve(prob;dt=0.1)
+
+  dt = 1//1000
+  t = 0:dt:1
+  W = NoiseGrid(t,brownian_values)
+  prob_rational = NoiseProblem(W,(0,1))
+  sol = solve(prob_rational; dt=1//10)
 end

--- a/test/reversal_test.jl
+++ b/test/reversal_test.jl
@@ -212,7 +212,7 @@ end
   prob1 = SDEProblem(b,σ,x0,(0.0,2.0-1e-11),noise=W1)
   sol1 = solve(prob1,EM(false),dt=dt,adaptive=false)
 
-  @test isapprox(xs, sol1.u, atol=1e-9)
+  @test isapprox(xs, sol1.u, atol=1e-8)
 
 
   W1rev = NoiseGrid(reverse(ts),reverse(W))

--- a/test/reversal_test.jl
+++ b/test/reversal_test.jl
@@ -1,6 +1,5 @@
-@testset "SDE Reversal Tests" begin
-
 using StochasticDiffEq, DiffEqNoiseProcess, Test, Random
+@testset "SDE Reversal Tests" begin
 Random.seed!(100)
 α=1.01
 β=0.87
@@ -143,3 +142,173 @@ sol2 = solve(prob2,EulerHeun(),dt=dt)
 @test sol1.u ≈ sol2.u atol=1e-5
 
 end
+
+
+@testset "SDE Ito Reversal Tests" begin
+
+n = 100000
+T = 2.0
+dt = T/n
+x0 = 0.3
+
+b(u,p,t) =  sin(t) + cos(u)
+σ(u,p,t) = pi + atan(u)
+
+seed = 10
+Random.seed!(seed)
+W = [0.0; cumsum(sqrt(dt)*randn(n))]
+#using Plots; plot(W)
+
+p = nothing
+
+"""
+For ito integrals
+"""
+
+x = x0 # starting point
+xs = [x]
+t = 0.0
+ts = [0.0]
+for i in 1:n
+    global t, x
+    #@show x, dt, (W[i+1] - W[i]), x+b(x,p,t)*dt, σ(x,p,t)*(W[i+1] - W[i])
+    x += b(x,p,t)*dt + σ(x,p,t)*(W[i+1] - W[i]) # this is an ito integral
+    t += dt
+    push!(xs, x)
+	push!(ts, t)
+
+end
+
+z = xs[end]
+
+#plt = plot(ts,xs)
+#plt = plot(xs)
+# Now reverse... t
+
+dσ_dx(u,p,t) = 1/(1 + u^2) # d(arctan(x))/dx
+z = xs[end]
+@show "starting point" z
+ys = [z]
+t = T
+cs = [0.0]
+for i in n:-1:1
+    global t, z
+    cor =  1/2*dσ_dx(z,p,t)*σ(z,p,t)
+    z -= (b(z,p,t)-0*2*cor)*dt + σ(z,p,t)*(W[i+1] - W[i]) # reverse ito integral
+    t -= dt
+    push!(ys, z)
+    push!(cs, cor)
+end
+
+#plot!(ts,reverse(ys))
+# difference between forward and backward
+#plot(reverse(ys)-xs)
+# correction terms
+#plot(cs)
+#using DiffEqNoiseProcess, StochasticDiffEq
+
+
+W1 = NoiseGrid(ts,W)
+prob1 = SDEProblem(b,σ,x0,(0.0,2.0-1e-11),noise=W1)
+sol1 = solve(prob1,EM(false),dt=dt,adaptive=false)
+
+@test isapprox(xs, sol1.u, atol=1e-9)
+
+
+W1rev = NoiseGrid(reverse(ts),reverse(W))
+prob1 = SDEProblem(b,σ,sol1.u[end],(sol1.t[end],sol1.t[1]),noise=W1rev)
+sol2 = solve(prob1,EM(false),dt=dt,adaptive=false)
+
+# plot(ts,reverse(ys))
+# plot!(reverse(ts), sol2.u)
+@test isapprox(ys,sol2.u, atol=1e-6)
+@test !isapprox(sol1.u,reverse(sol2.u), atol=1e-0)
+
+bwrong(u,p,t) =  b(u,p,t) - 1//2*dσ_dx(u,p,t)*σ(u,p,t)
+W1rev = NoiseGrid(reverse(ts),reverse(W))
+prob1 = SDEProblem(bwrong,σ,sol1.u[end],(sol1.t[end],sol1.t[1]),noise=W1rev)
+sol2 = solve(prob1,EM(false),dt=dt,adaptive=false)
+
+@test !isapprox(ys,sol2.u, atol=1e-0)
+@test !isapprox(sol1.u,reverse(sol2.u), atol=1e-0)
+
+bcorrected(u,p,t) =  b(u,p,t) - 2*1//2*dσ_dx(u,p,t)*σ(u,p,t)
+W1rev = NoiseGrid(reverse(ts),reverse(W))
+prob1 = SDEProblem(bcorrected,σ,sol1.u[end],(sol1.t[end],sol1.t[1]),noise=W1rev)
+sol2 = solve(prob1,EM(false),dt=dt,adaptive=false)
+
+#plot(ts, sol1.u - reverse(sol2.u))
+@test !isapprox(ys,sol2.u, atol=1e-6)
+@test isapprox(sol1.u,reverse(sol2.u), atol=1e-0)
+
+end
+
+
+
+"""
+Some more Ito reversals
+"""
+
+Random.seed!(100)
+α=1.0
+β=2.0
+
+dt = 1e-3
+tspan = (0.0,1.0)
+u₀=1/2
+
+tarray =  collect(tspan[1]:dt:tspan[2])
+
+f!(du,u,p,t) = du .= α*u
+g!(du,u,p,t) = du .= β*u
+
+
+prob = SDEProblem(f!,g!,[u₀],tspan)
+sol = solve(prob,SOSRI(),dt=dt,save_noise=true, adaptive=false)
+
+_sol = deepcopy(sol) # to make sure the plot is correct
+W1 = NoiseGrid(reverse!(_sol.t),reverse!(_sol.W.W)
+  ,reverse!(_sol.W.Z)
+  )
+prob1 = SDEProblem(f!,g!,sol[end],reverse(tspan),noise=W1)
+sol1 = solve(prob1,SOSRI(),dt=dt, adaptive=false)
+
+_sol = deepcopy(sol)
+W2 = NoiseWrapper(_sol.W, reverse=true)
+prob2 = SDEProblem(f!,g!,sol[end],reverse(tspan),noise=W2)
+sol2 = solve(prob2,SOSRI(),dt=dt, save_noise=false, adaptive=false)
+
+# same time steps
+
+@test sol.u ≈ reverse(sol1.u) atol=1e-2
+@test sol.u ≈ reverse(sol2.u) atol=1e-2
+@test sol1.u ≈ sol2.u atol=1e-4
+
+using Plots; plt = plot(sol)
+plot!(reverse(sol1.t),reverse(sol1[1,:]))
+plot(vcat(sol.u - reverse(sol1.u) ...))
+
+plot(vcat(sol1.u - sol2.u ...))
+
+
+f(u,p,t) = α*u
+g(u,p,t) = β*u
+
+prob = SDEProblem(f,g,u₀,tspan)
+sol =solve(prob,SOSRI(),dt=dt,save_noise=true, adaptive=false)
+
+_sol = deepcopy(sol) # to make sure the plot is correct
+W1 = NoiseGrid(reverse!(_sol.t),reverse!(_sol.W.W)
+   ,reverse!(_sol.W.Z)
+   )
+prob1 = SDEProblem(f,g,sol[end],reverse(tspan),noise=W1)
+sol1 = solve(prob1,SOSRI(),dt=dt, adaptive=false)
+
+_sol = deepcopy(sol)
+W2 = NoiseWrapper(_sol.W, reverse=true)
+prob2 = SDEProblem(f,g,sol[end],reverse(tspan),noise=W2)
+sol2 = solve(prob2,SOSRI(),dt=dt, adaptive=false)
+
+@test sol.u ≈ reverse(sol1.u) atol=5e-2
+@test sol.u ≈ reverse(sol2.u) atol=5e-2
+@test sol1.u ≈ sol2.u atol=1e-5

--- a/test/reversal_test.jl
+++ b/test/reversal_test.jl
@@ -248,6 +248,8 @@ end
 """
 Some more Ito reversals
 """
+
+
 @testset "SDE Ito Reversal Tests" begin
   Random.seed!(100)
   α=1.0

--- a/test/reversal_test.jl
+++ b/test/reversal_test.jl
@@ -1,175 +1,175 @@
 using StochasticDiffEq, DiffEqNoiseProcess, Test, Random
 @testset "SDE Reversal Tests" begin
-Random.seed!(100)
-α=1.01
-β=0.87
+  Random.seed!(100)
+  α=1.01
+  β=0.87
 
-dt = 1e-3
-tspan = (0.0,1.0)
-u₀=1/2
+  dt = 1e-3
+  tspan = (0.0,1.0)
+  u₀=1/2
 
-tarray =  collect(tspan[1]:dt:tspan[2])
+  tarray =  collect(tspan[1]:dt:tspan[2])
 
-f!(du,u,p,t) = du .= α*u
-g!(du,u,p,t) = du .= β*u
-
-
-prob = SDEProblem(f!,g!,[u₀],tspan)
-sol =solve(prob,EulerHeun(),dt=dt,save_noise=true, adaptive=false)
-
-_sol = deepcopy(sol) # to make sure the plot is correct
-W1 = NoiseGrid(reverse!(_sol.t),reverse!(_sol.W.W))
-prob1 = SDEProblem(f!,g!,sol[end],reverse(tspan),noise=W1)
-sol1 = solve(prob1,EulerHeun(),dt=dt)
-
-_sol = deepcopy(sol)
-W2 = NoiseWrapper(_sol.W, reverse=true)
-prob2 = SDEProblem(f!,g!,sol[end],reverse(tspan),noise=W2)
-sol2 = solve(prob2,EulerHeun(),dt=dt, save_noise=false)
-
-# same time steps
-
-@test sol.u ≈ reverse(sol1.u) atol=1e-2
-@test sol.u ≈ reverse(sol2.u) atol=1e-2
-@test sol1.u ≈ sol2.u atol=1e-5
-
-# 1/10 size time steps
-
-_sol = deepcopy(sol) # to make sure the plot is correct
-W1 = NoiseGrid(reverse!(_sol.t),reverse!(_sol.W.W))
-prob1 = SDEProblem(f!,g!,sol[end],reverse(tspan),noise=W1)
-sol1 = solve(prob1,EulerHeun(),dt=0.1*dt)
-
-_sol = deepcopy(sol)
-W2 = NoiseWrapper(_sol.W, reverse=true)
-prob2 = SDEProblem(f!,g!,sol[end],reverse(tspan),noise=W2)
-sol2 = solve(prob2,EulerHeun(),dt=0.1*dt, save_noise=false)
-
-@test sol.u ≈ sol1(tarray).u atol=1e-2
-@test sol.u ≈ sol2(tarray).u atol=1e-2
+  f!(du,u,p,t) = du .= α*u
+  g!(du,u,p,t) = du .= β*u
 
 
-# diagonal noise
+  prob = SDEProblem(f!,g!,[u₀],tspan)
+  sol =solve(prob,EulerHeun(),dt=dt,save_noise=true, adaptive=false)
 
-prob = SDEProblem(f!,g!,[u₀,u₀],tspan)
-sol = solve(prob,EulerHeun(),dt=dt,save_noise=true)
+  _sol = deepcopy(sol) # to make sure the plot is correct
+  W1 = NoiseGrid(reverse!(_sol.t),reverse!(_sol.W.W))
+  prob1 = SDEProblem(f!,g!,sol[end],reverse(tspan),noise=W1)
+  sol1 = solve(prob1,EulerHeun(),dt=dt)
 
-_sol = deepcopy(sol) # to make sure the plot is correct
-W1 = NoiseGrid(reverse!(_sol.t),reverse!(_sol.W.W))
-prob1 = SDEProblem(f!,g!,sol[end],reverse(tspan),noise=W1)
-sol1 = solve(prob1,EulerHeun(),dt=dt)
+  _sol = deepcopy(sol)
+  W2 = NoiseWrapper(_sol.W, reverse=true)
+  prob2 = SDEProblem(f!,g!,sol[end],reverse(tspan),noise=W2)
+  sol2 = solve(prob2,EulerHeun(),dt=dt, save_noise=false)
 
-_sol = deepcopy(sol)
-W2 = NoiseWrapper(_sol.W, reverse=true)
-prob2 = SDEProblem(f!,g!,sol[end],reverse(tspan),noise=W2)
-sol2 = solve(prob2,EulerHeun(),dt=dt)
+  # same time steps
 
-@test sol.u ≈ reverse(sol1.u) atol=5e-2
-@test sol.u ≈ reverse(sol2.u) atol=5e-2
-@test sol1.u ≈ sol2.u atol=1e-5
+  @test sol.u ≈ reverse(sol1.u) atol=1e-2
+  @test sol.u ≈ reverse(sol2.u) atol=1e-2
+  @test sol1.u ≈ sol2.u atol=1e-5
+
+  # 1/10 size time steps
+
+  _sol = deepcopy(sol) # to make sure the plot is correct
+  W1 = NoiseGrid(reverse!(_sol.t),reverse!(_sol.W.W))
+  prob1 = SDEProblem(f!,g!,sol[end],reverse(tspan),noise=W1)
+  sol1 = solve(prob1,EulerHeun(),dt=0.1*dt)
+
+  _sol = deepcopy(sol)
+  W2 = NoiseWrapper(_sol.W, reverse=true)
+  prob2 = SDEProblem(f!,g!,sol[end],reverse(tspan),noise=W2)
+  sol2 = solve(prob2,EulerHeun(),dt=0.1*dt, save_noise=false)
+
+  @test sol.u ≈ sol1(tarray).u atol=1e-2
+  @test sol.u ≈ sol2(tarray).u atol=1e-2
 
 
-# non-diagonal noise
+  # diagonal noise
 
-function gnd!(du,u,p,t)
-  du[1,1] = 0.3u[1]
-  du[1,2] = 0.6u[1]
-  du[1,3] = 0.9u[1]
-  du[1,4] = 0.12u[2]
-  du[2,1] = 1.2u[1]
-  du[2,2] = 0.2u[2]
-  du[2,3] = 0.3u[2]
-  du[2,4] = 1.8u[2]
-end
-prob = SDEProblem(f!,gnd!,[u₀,u₀],tspan,noise_rate_prototype=zeros(2,4))
-sol = solve(prob,EulerHeun(),dt=dt,save_noise=true)
+  prob = SDEProblem(f!,g!,[u₀,u₀],tspan)
+  sol = solve(prob,EulerHeun(),dt=dt,save_noise=true)
 
-_sol = deepcopy(sol) # to make sure the plot is correct
-W1 = NoiseGrid(reverse!(_sol.t),reverse!(_sol.W.W))
-prob1 = SDEProblem(f!,gnd!,sol[end],reverse(tspan),noise=W1,noise_rate_prototype=zeros(2,4))
-sol1 = solve(prob1,EulerHeun(),dt=dt)
+  _sol = deepcopy(sol) # to make sure the plot is correct
+  W1 = NoiseGrid(reverse!(_sol.t),reverse!(_sol.W.W))
+  prob1 = SDEProblem(f!,g!,sol[end],reverse(tspan),noise=W1)
+  sol1 = solve(prob1,EulerHeun(),dt=dt)
 
-_sol = deepcopy(sol)
-W2 = NoiseWrapper(_sol.W, reverse=true)
-prob2 = SDEProblem(f!,gnd!,sol[end],reverse(tspan),noise=W2, noise_rate_prototype=zeros(2,4))
-sol2 = solve(prob2,EulerHeun(),dt=dt)
+  _sol = deepcopy(sol)
+  W2 = NoiseWrapper(_sol.W, reverse=true)
+  prob2 = SDEProblem(f!,g!,sol[end],reverse(tspan),noise=W2)
+  sol2 = solve(prob2,EulerHeun(),dt=dt)
 
-@test sol.u ≈ reverse(sol1.u) atol=5e-1
-@test sol.u ≈ reverse(sol2.u) atol=5e-1
-@test sol1.u ≈ sol2.u atol=1e-5
+  @test sol.u ≈ reverse(sol1.u) atol=5e-2
+  @test sol.u ≈ reverse(sol2.u) atol=5e-2
+  @test sol1.u ≈ sol2.u atol=1e-5
 
-###
-### OOP
-###
 
-f(u,p,t) = α*u
-g(u,p,t) = β*u
+  # non-diagonal noise
 
-prob = SDEProblem(f,g,u₀,tspan)
-sol =solve(prob,EulerHeun(),dt=dt,save_noise=true)
+  function gnd!(du,u,p,t)
+    du[1,1] = 0.3u[1]
+    du[1,2] = 0.6u[1]
+    du[1,3] = 0.9u[1]
+    du[1,4] = 0.12u[2]
+    du[2,1] = 1.2u[1]
+    du[2,2] = 0.2u[2]
+    du[2,3] = 0.3u[2]
+    du[2,4] = 1.8u[2]
+  end
+  prob = SDEProblem(f!,gnd!,[u₀,u₀],tspan,noise_rate_prototype=zeros(2,4))
+  sol = solve(prob,EulerHeun(),dt=dt,save_noise=true)
 
-_sol = deepcopy(sol) # to make sure the plot is correct
-W1 = NoiseGrid(reverse!(_sol.t),reverse!(_sol.W.W))
-prob1 = SDEProblem(f,g,sol[end],reverse(tspan),noise=W1)
-sol1 = solve(prob1,EulerHeun(),dt=dt)
+  _sol = deepcopy(sol) # to make sure the plot is correct
+  W1 = NoiseGrid(reverse!(_sol.t),reverse!(_sol.W.W))
+  prob1 = SDEProblem(f!,gnd!,sol[end],reverse(tspan),noise=W1,noise_rate_prototype=zeros(2,4))
+  sol1 = solve(prob1,EulerHeun(),dt=dt)
 
-_sol = deepcopy(sol)
-W2 = NoiseWrapper(_sol.W, reverse=true)
-prob2 = SDEProblem(f,g,sol[end],reverse(tspan),noise=W2)
-sol2 = solve(prob2,EulerHeun(),dt=dt)
+  _sol = deepcopy(sol)
+  W2 = NoiseWrapper(_sol.W, reverse=true)
+  prob2 = SDEProblem(f!,gnd!,sol[end],reverse(tspan),noise=W2, noise_rate_prototype=zeros(2,4))
+  sol2 = solve(prob2,EulerHeun(),dt=dt)
 
-@test sol.u ≈ reverse(sol1.u) atol=2e-2
-@test sol.u ≈ reverse(sol2.u) atol=2e-2
-@test sol1.u ≈ sol2.u atol=1e-5
+  @test sol.u ≈ reverse(sol1.u) atol=5e-1
+  @test sol.u ≈ reverse(sol2.u) atol=5e-1
+  @test sol1.u ≈ sol2.u atol=1e-5
 
-# diagonal noise
+  ###
+  ### OOP
+  ###
 
-prob = SDEProblem(f,g,[u₀,u₀],tspan)
-sol = solve(prob,EulerHeun(),dt=dt,save_noise=true)
+  f(u,p,t) = α*u
+  g(u,p,t) = β*u
 
-_sol = deepcopy(sol) # to make sure the plot is correct
-W1 = NoiseGrid(reverse!(_sol.t),reverse!(_sol.W.W))
-prob1 = SDEProblem(f,g,sol[end],reverse(tspan),noise=W1)
-sol1 = solve(prob1,EulerHeun(),dt=dt)
+  prob = SDEProblem(f,g,u₀,tspan)
+  sol =solve(prob,EulerHeun(),dt=dt,save_noise=true)
 
-_sol = deepcopy(sol)
-W2 = NoiseWrapper(_sol.W, reverse=true)
-prob2 = SDEProblem(f,g,sol[end],reverse(tspan),noise=W2)
-sol2 = solve(prob2,EulerHeun(),dt=dt)
+  _sol = deepcopy(sol) # to make sure the plot is correct
+  W1 = NoiseGrid(reverse!(_sol.t),reverse!(_sol.W.W))
+  prob1 = SDEProblem(f,g,sol[end],reverse(tspan),noise=W1)
+  sol1 = solve(prob1,EulerHeun(),dt=dt)
 
-@test sol.u ≈ reverse(sol1.u) atol=5e-2
-@test sol.u ≈ reverse(sol2.u) atol=5e-2
-@test sol1.u ≈ sol2.u atol=1e-5
+  _sol = deepcopy(sol)
+  W2 = NoiseWrapper(_sol.W, reverse=true)
+  prob2 = SDEProblem(f,g,sol[end],reverse(tspan),noise=W2)
+  sol2 = solve(prob2,EulerHeun(),dt=dt)
+
+  @test sol.u ≈ reverse(sol1.u) atol=2e-2
+  @test sol.u ≈ reverse(sol2.u) atol=2e-2
+  @test sol1.u ≈ sol2.u atol=1e-5
+
+  # diagonal noise
+
+  prob = SDEProblem(f,g,[u₀,u₀],tspan)
+  sol = solve(prob,EulerHeun(),dt=dt,save_noise=true)
+
+  _sol = deepcopy(sol) # to make sure the plot is correct
+  W1 = NoiseGrid(reverse!(_sol.t),reverse!(_sol.W.W))
+  prob1 = SDEProblem(f,g,sol[end],reverse(tspan),noise=W1)
+  sol1 = solve(prob1,EulerHeun(),dt=dt)
+
+  _sol = deepcopy(sol)
+  W2 = NoiseWrapper(_sol.W, reverse=true)
+  prob2 = SDEProblem(f,g,sol[end],reverse(tspan),noise=W2)
+  sol2 = solve(prob2,EulerHeun(),dt=dt)
+
+  @test sol.u ≈ reverse(sol1.u) atol=5e-2
+  @test sol.u ≈ reverse(sol2.u) atol=5e-2
+  @test sol1.u ≈ sol2.u atol=1e-5
 
 end
 
 
 @testset "SDE Ito Reversal Tests" begin
 
-n = 100000
-T = 2.0
-dt = T/n
-x0 = 0.3
+  n = 100000
+  T = 2.0
+  dt = T/n
+  x0 = 0.3
 
-b(u,p,t) =  sin(t) + cos(u)
-σ(u,p,t) = pi + atan(u)
+  b(u,p,t) =  sin(t) + cos(u)
+  σ(u,p,t) = pi + atan(u)
 
-seed = 10
-Random.seed!(seed)
-W = [0.0; cumsum(sqrt(dt)*randn(n))]
-#using Plots; plot(W)
+  seed = 10
+  Random.seed!(seed)
+  W = [0.0; cumsum(sqrt(dt)*randn(n))]
+  #using Plots; plot(W)
 
-p = nothing
+  p = nothing
 
-"""
-For ito integrals
-"""
+  """
+  For ito integrals
+  """
 
-x = x0 # starting point
-xs = [x]
-t = 0.0
-ts = [0.0]
-for i in 1:n
+  x = x0 # starting point
+  xs = [x]
+  t = 0.0
+  ts = [0.0]
+  for i in 1:n
     global t, x
     #@show x, dt, (W[i+1] - W[i]), x+b(x,p,t)*dt, σ(x,p,t)*(W[i+1] - W[i])
     x += b(x,p,t)*dt + σ(x,p,t)*(W[i+1] - W[i]) # this is an ito integral
@@ -177,69 +177,69 @@ for i in 1:n
     push!(xs, x)
 	push!(ts, t)
 
-end
+  end
 
-z = xs[end]
+  z = xs[end]
 
-#plt = plot(ts,xs)
-#plt = plot(xs)
-# Now reverse... t
+  #plt = plot(ts,xs)
+  #plt = plot(xs)
+  # Now reverse... t
 
-dσ_dx(u,p,t) = 1/(1 + u^2) # d(arctan(x))/dx
-z = xs[end]
-@show "starting point" z
-ys = [z]
-t = T
-cs = [0.0]
-for i in n:-1:1
+  dσ_dx(u,p,t) = 1/(1 + u^2) # d(arctan(x))/dx
+  z = xs[end]
+  @show "starting point" z
+  ys = [z]
+  t = T
+  cs = [0.0]
+  for i in n:-1:1
     global t, z
     cor =  1/2*dσ_dx(z,p,t)*σ(z,p,t)
     z -= (b(z,p,t)-0*2*cor)*dt + σ(z,p,t)*(W[i+1] - W[i]) # reverse ito integral
     t -= dt
     push!(ys, z)
     push!(cs, cor)
-end
+  end
 
-#plot!(ts,reverse(ys))
-# difference between forward and backward
-#plot(reverse(ys)-xs)
-# correction terms
-#plot(cs)
-#using DiffEqNoiseProcess, StochasticDiffEq
-
-
-W1 = NoiseGrid(ts,W)
-prob1 = SDEProblem(b,σ,x0,(0.0,2.0-1e-11),noise=W1)
-sol1 = solve(prob1,EM(false),dt=dt,adaptive=false)
-
-@test isapprox(xs, sol1.u, atol=1e-9)
+  #plot!(ts,reverse(ys))
+  # difference between forward and backward
+  #plot(reverse(ys)-xs)
+  # correction terms
+  #plot(cs)
+  #using DiffEqNoiseProcess, StochasticDiffEq
 
 
-W1rev = NoiseGrid(reverse(ts),reverse(W))
-prob1 = SDEProblem(b,σ,sol1.u[end],(sol1.t[end],sol1.t[1]),noise=W1rev)
-sol2 = solve(prob1,EM(false),dt=dt,adaptive=false)
+  W1 = NoiseGrid(ts,W)
+  prob1 = SDEProblem(b,σ,x0,(0.0,2.0-1e-11),noise=W1)
+  sol1 = solve(prob1,EM(false),dt=dt,adaptive=false)
 
-# plot(ts,reverse(ys))
-# plot!(reverse(ts), sol2.u)
-@test isapprox(ys,sol2.u, atol=1e-6)
-@test !isapprox(sol1.u,reverse(sol2.u), atol=1e-0)
+  @test isapprox(xs, sol1.u, atol=1e-9)
 
-bwrong(u,p,t) =  b(u,p,t) - 1//2*dσ_dx(u,p,t)*σ(u,p,t)
-W1rev = NoiseGrid(reverse(ts),reverse(W))
-prob1 = SDEProblem(bwrong,σ,sol1.u[end],(sol1.t[end],sol1.t[1]),noise=W1rev)
-sol2 = solve(prob1,EM(false),dt=dt,adaptive=false)
 
-@test !isapprox(ys,sol2.u, atol=1e-0)
-@test !isapprox(sol1.u,reverse(sol2.u), atol=1e-0)
+  W1rev = NoiseGrid(reverse(ts),reverse(W))
+  prob1 = SDEProblem(b,σ,sol1.u[end],(sol1.t[end],sol1.t[1]),noise=W1rev)
+  sol2 = solve(prob1,EM(false),dt=dt,adaptive=false)
 
-bcorrected(u,p,t) =  b(u,p,t) - 2*1//2*dσ_dx(u,p,t)*σ(u,p,t)
-W1rev = NoiseGrid(reverse(ts),reverse(W))
-prob1 = SDEProblem(bcorrected,σ,sol1.u[end],(sol1.t[end],sol1.t[1]),noise=W1rev)
-sol2 = solve(prob1,EM(false),dt=dt,adaptive=false)
+  # plot(ts,reverse(ys))
+  # plot!(reverse(ts), sol2.u)
+  @test isapprox(ys,sol2.u, atol=1e-6)
+  @test !isapprox(sol1.u,reverse(sol2.u), atol=1e-0)
 
-#plot(ts, sol1.u - reverse(sol2.u))
-@test !isapprox(ys,sol2.u, atol=1e-6)
-@test isapprox(sol1.u,reverse(sol2.u), atol=1e-0)
+  bwrong(u,p,t) =  b(u,p,t) - 1//2*dσ_dx(u,p,t)*σ(u,p,t)
+  W1rev = NoiseGrid(reverse(ts),reverse(W))
+  prob1 = SDEProblem(bwrong,σ,sol1.u[end],(sol1.t[end],sol1.t[1]),noise=W1rev)
+  sol2 = solve(prob1,EM(false),dt=dt,adaptive=false)
+
+  @test !isapprox(ys,sol2.u, atol=1e-0)
+  @test !isapprox(sol1.u,reverse(sol2.u), atol=1e-0)
+
+  bcorrected(u,p,t) =  b(u,p,t) - 2*1//2*dσ_dx(u,p,t)*σ(u,p,t)
+  W1rev = NoiseGrid(reverse(ts),reverse(W))
+  prob1 = SDEProblem(bcorrected,σ,sol1.u[end],(sol1.t[end],sol1.t[1]),noise=W1rev)
+  sol2 = solve(prob1,EM(false),dt=dt,adaptive=false)
+
+  #plot(ts, sol1.u - reverse(sol2.u))
+  @test !isapprox(ys,sol2.u, atol=1e-6)
+  @test isapprox(sol1.u,reverse(sol2.u), atol=1e-0)
 
 end
 


### PR DESCRIPTION
Cleans two (small) index errors in NoiseGrid and adds reversal tests for Ito SDEs (useful for https://github.com/SciML/DiffEqSensitivity.jl/pull/317 and https://github.com/SciML/DiffEqSensitivity.jl/issues/279)

I'd like to note that I had problems with the reversal of the Ito SDE using `SOSRI()` (which is also a Stochastic Runge Kutta solver for Ito SDEs). While for `EM()` the tests show that the proper correction factor for the reverse Ito SDEs is  given upon subtraction of 2 times the  standard Ito-Stratonovich factor, for `SOSRI()` the tests were actually passing if I omit the correction.
(Maybe @mschauer has an idea here?)

Otherwise it should be fine if all other tests are passing