### PR TITLE
Dispatch for reversion of a given noise process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ julia:
 #    - julia: nightly
 notifications:
   email: false
-after_success:
-  - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';
-  - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())';
+
+# uncomment the following lines to override the default test script
+script: julia -e 'using Pkg; Pkg.build(); Pkg.test(coverage=false)'
+#after_success:
+#  - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
+#  - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'

--- a/src/noise_interfaces/common.jl
+++ b/src/noise_interfaces/common.jl
@@ -66,3 +66,14 @@ function DiffEqBase.reinit!(W::AbstractNoiseProcess,dt;
   setup_next && setup_next_step!(W)
   return nothing
 end
+
+
+function DiffEqBase.reverse(W::AbstractNoiseProcess)
+  if typeof(W) <: NoiseGrid
+    backwardnoise = NoiseGrid(reverse(W.t),reverse(W.W))
+  else
+    W.save_everystep = false
+    backwardnoise = NoiseWrapper(W, reverse=true)
+  end
+  return backwardnoise
+end

--- a/src/noise_interfaces/common.jl
+++ b/src/noise_interfaces/common.jl
@@ -68,7 +68,7 @@ function DiffEqBase.reinit!(W::AbstractNoiseProcess,dt;
 end
 
 
-function DiffEqBase.reverse(W::AbstractNoiseProcess)
+function Base.reverse(W::AbstractNoiseProcess)
   if typeof(W) <: NoiseGrid
     backwardnoise = NoiseGrid(reverse(W.t),reverse(W.W))
   else

--- a/src/noise_interfaces/noise_grid_interface.jl
+++ b/src/noise_interfaces/noise_grid_interface.jl
@@ -45,8 +45,8 @@ end
 
 function interpolate!(out1,out2,W::NoiseGrid,t)
   ts,timeseries,timeseries2 = W.t,W.W,W.Z
-  sign(W.dt)*t > sign(W.dt)*ts[end] && error("Solution interpolation cannot extrapolate past the final timepoint. Build a longer NoiseGrid to cover the integration.")
-  sign(W.dt)*t < sign(W.dt)*ts[1] && error("Solution interpolation cannot extrapolate before the first timepoint. Build a longer NoiseGrid to cover the integration.")
+  sign(W.dt)*t > sign(W.dt)*(ts[end]+10eps(typeof(t))) && error("Solution interpolation cannot extrapolate past the final timepoint. Build a longer NoiseGrid to cover the integration.")
+  sign(W.dt)*t < sign(W.dt)*(ts[1]-10eps(typeof(t))) && error("Solution interpolation cannot extrapolate before the first timepoint. Build a longer NoiseGrid to cover the integration.")
   tdir = sign(ts[end]-ts[1])
 
 
@@ -109,7 +109,7 @@ function accept_step!(W::NoiseGrid,dt,u,p,setup_next=true)
   end
 
   W.dt = dt #dtpropose
-  if sign(W.dt)*(W.curt + W.dt) > sign(W.dt)*W.t[end]
+  if sign(W.dt)*(W.curt + W.dt) > sign(W.dt)*(W.t[end]+sign(W.dt)*10eps(typeof(dt)))
     setup_next = false
     W.step_setup = false
   end

--- a/src/noise_interfaces/noise_grid_interface.jl
+++ b/src/noise_interfaces/noise_grid_interface.jl
@@ -109,9 +109,16 @@ function accept_step!(W::NoiseGrid,dt,u,p,setup_next=true)
   end
 
   W.dt = dt #dtpropose
-  if sign(W.dt)*(W.curt + W.dt) > sign(W.dt)*(W.t[end]+sign(W.dt)*10eps(typeof(dt)))
-    setup_next = false
-    W.step_setup = false
+  if (W.dt isa Union{Rational,Integer})
+    if sign(W.dt)*(W.curt + W.dt) > sign(W.dt)*W.t[end]
+      setup_next = false
+      W.step_setup = false
+    end
+  else
+    if sign(W.dt)*(W.curt + W.dt) > sign(W.dt)*(W.t[end]+sign(W.dt)*10eps(typeof(dt)))
+      setup_next = false
+      W.step_setup = false
+    end  
   end
 
   if setup_next

--- a/src/noise_interfaces/noise_grid_interface.jl
+++ b/src/noise_interfaces/noise_grid_interface.jl
@@ -45,8 +45,8 @@ end
 
 function interpolate!(out1,out2,W::NoiseGrid,t)
   ts,timeseries,timeseries2 = W.t,W.W,W.Z
-  sign(W.dt)*t > sign(W.dt)*(ts[end]+10eps(typeof(t))) && error("Solution interpolation cannot extrapolate past the final timepoint. Build a longer NoiseGrid to cover the integration.")
-  sign(W.dt)*t < sign(W.dt)*(ts[1]-10eps(typeof(t))) && error("Solution interpolation cannot extrapolate before the first timepoint. Build a longer NoiseGrid to cover the integration.")
+  sign(W.dt)*t > sign(W.dt)*(ts[end]+10*sign(W.dt)*eps(typeof(t))) && error("Solution interpolation cannot extrapolate past the final timepoint. Build a longer NoiseGrid to cover the integration.")
+  sign(W.dt)*t < sign(W.dt)*(ts[1]+10*sign(W.dt)*eps(typeof(t))) && error("Solution interpolation cannot extrapolate before the first timepoint. Build a longer NoiseGrid to cover the integration.")
   tdir = sign(ts[end]-ts[1])
 
 

--- a/test/sde_adaptivedistribution_tests.jl
+++ b/test/sde_adaptivedistribution_tests.jl
@@ -25,7 +25,7 @@ end
 for j = 1:M
   Wends = Vector{Float64}(undef,N)
   for i = 1:N
-    sol =solve(prob,SRI(),dt=1/2^(4),abstol=1e-2,reltol=0,adaptivealg=:RSwM2)
+    sol = solve(prob,SRI(),dt=1/2^(4),abstol=1e-2,reltol=0,adaptivealg=:RSwM2)
     Wends[i] = sol.W.W[end]
   end
   kssol = ApproximateOneSampleKSTest(Wends/sqrt(T), Normal())


### PR DESCRIPTION
Currently, we run into an error when a `NoiseGrid` is used in the forward pass and we'd like to compute the gradients, e.g.,  using the SDE BacksolveAdjoint:

https://github.com/SciML/DiffEqSensitivity.jl/blob/20a09e98c01935d6ddccfb1aa27e5adb094b1e6f/src/local_sensitivity/backsolve_adjoint.jl#L188

The added dispatch allows us to compute the noise for the backward pass by

```julia
backwardnoise = reverse(sol.W)
```

such that if a `WienerProcess` is used forward, a  `WienerProcess` is used backward, etc.