### PR TITLE
reduce allocations

### DIFF
--- a/src/wiener.jl
+++ b/src/wiener.jl
@@ -3,6 +3,9 @@ const one_over_sqrt2 = 1/sqrt(2)
 @inline function wiener_randn(rng::AbstractRNG,proto::Array{T}) where T
   randn(rng,size(proto))
 end
+@inline function wiener_randn(rng::AbstractRNG,proto::T) where {T <: SArray}
+  randn(rng,T)
+end
 @inline function wiener_randn(rng::AbstractRNG,proto)
   convert(typeof(proto),randn(rng,size(proto)))
 end


### PR DESCRIPTION
This seems to reduce the memory allocated in https://github.com/SciML/StochasticDiffEq.jl/issues/365 by about a factor of 6-7. There still seems to be way too many allocations occurring (about 200K for the example there). (There are a number of places in the same file where specialization on static arrays could still be added, for example in some of the bridging code, but I only made the minimal change that seemed helpful here.)