### PR TITLE
RSWm3 correctness

### DIFF
--- a/src/noise_interfaces/noise_process_interface.jl
+++ b/src/noise_interfaces/noise_process_interface.jl
@@ -245,75 +245,72 @@ end
     end
     while !isempty(W.S₂)
       L₁,L₂,L₃ = pop!(W.S₂)
-      if dttmp + L₁ < (1-q)*W.dt #while the backwards movement is less than chop off
-        dttmp += L₁
-        if isinplace(W)
-          @.. W.dWtmp += L₂
-          if W.Z != nothing
-            @.. W.dZtmp += L₃
-          end
-        else
-          W.dWtmp += L₂
-          if W.Z != nothing
-            W.dZtmp += L₃
-          end
+      dttmp += L₁
+      if isinplace(W)
+        @.. W.dWtmp += L₂
+        if W.Z != nothing
+          @.. W.dZtmp += L₃
         end
+      else
+        W.dWtmp += L₂
+        if W.Z != nothing
+          W.dZtmp += L₃
+        end
+      end
+      if dttmp < (1-q)*W.dt #while the backwards movement is less than chop off
         push!(W.S₁,(L₁,L₂,L₃))
       else
-        push!(W.S₂,(L₁,L₂,L₃))
+        dtM = (q-1)*W.dt + dttmp + L₁
+        qM = dtM/L₁
+        if isinplace(W)
+          W.bridge(W.dWtilde,W,0,L₂,qM,dtM,u,p,W.curt,W.rng)
+          if W.Z != nothing
+            W.bridge(W.dZtilde,W,0,L₃,qM,dtM,u,p,W.curt,W.rng)
+          end
+        else
+          W.dWtilde = W.bridge(W.dW,W,0,L₂,qM,dtM,u,p,W.curt,W.rng)
+          if W.Z != nothing
+            W.dZtilde = W.bridge(W.dZ,W,0,L₃,qM,dtM,u,p,W.curt,W.rng)
+          end
+        end
+        # This is a control variable so do not diff through it
+        cutLength = DiffEqBase.ODE_DEFAULT_NORM((1-qM)*dtM,W.curt)
+        if cutLength > W.rswm.discard_length
+          if W.Z == nothing
+            push!(W.S₁,(cutLength,L₂-W.dWtilde,nothing))
+          else
+            push!(W.S₁,(cutLength,L₂-W.dWtilde,L₃-W.dZtilde))
+          end
+        end
+        if length(W.S₁) > W.maxstacksize
+          W.maxstacksize = length(W.S₁)
+        end
+        cutLength = DiffEqBase.ODE_DEFAULT_NORM(qM*dtM,W.curt)
+        if cutLength > W.rswm.discard_length
+          if W.Z == nothing
+            push!(W.S₂,(cutLength,W.dWtilde,nothing))
+          else
+            push!(W.S₂,(cutLength,W.dWtilde,W.dZtilde))
+          end
+        end
+        if length(W.S₂) > W.maxstacksize2
+            W.maxstacksize = length(W.S₂)
+        end
         break
       end
     end # end while
-    dtK = W.dt - dttmp
-    qK = q*W.dt/dtK
     if isinplace(W)
-      @.. W.dWtmp = W.dW - W.dWtmp
+      @.. W.dW += W.dWtilde - W.dWtmp
       if W.Z != nothing
-        @.. W.dZtmp = W.dZ - W.dZtmp
+        @.. W.dZ += W.dZtilde - W.dZtmp
       end
     else
-      W.dWtmp = W.dW - W.dWtmp
+      W.dW += W.dWtilde - W.dWtmp
       if W.Z != nothing
-        W.dZtmp = W.dZ - W.dZtmp
+        W.dZ += W.dZtilde - W.dZtmp
       end
-    end
-    if isinplace(W)
-      W.bridge(W.dWtilde,W,0,W.dWtmp,qK,dtK,u,p,W.curt,W.rng)
-      #W.dWtilde .-= W.curW
-      if W.Z != nothing
-        W.bridge(W.dZtilde,W,0,W.dZtmp,qK,dtK,u,p,W.curt,W.rng)
-        #W.dZtilde .-= W.curZ
-      end
-    else
-      W.dWtilde = W.bridge(W.dW,W,0,W.dWtmp,qK,dtK,u,p,W.curt,W.rng)# - W.curW
-      if W.Z != nothing
-        W.dZtilde = W.bridge(W.dZ,W,0,W.dZtmp,qK,dtK,u,p,W.curt,W.rng)# - W.curZ
-      end
-    end
-    # This is a control variable so do not diff through it
-    cutLength = DiffEqBase.ODE_DEFAULT_NORM((1-qK)*dtK,W.curt)
-    if cutLength > W.rswm.discard_length
-      if W.Z == nothing
-        push!(W.S₁,(cutLength,W.dWtmp-W.dWtilde,nothing))
-      else
-        push!(W.S₁,(cutLength,W.dWtmp-W.dWtilde,W.dZtmp-W.dZtilde))
-      end
-    end
-    if length(W.S₁) > W.maxstacksize
-        W.maxstacksize = length(W.S₁)
     end
     W.dt = dtnew
-    if isinplace(W)
-      copyto!(W.dW,W.dWtilde)
-      if W.Z != nothing
-        copyto!(W.dZ,W.dZtilde)
-      end
-    else
-      W.dW = W.dWtilde
-      if W.Z != nothing
-        W.dZ = W.dZtilde
-      end
-    end
   end
   return nothing
 end

--- a/src/noise_interfaces/noise_process_interface.jl
+++ b/src/noise_interfaces/noise_process_interface.jl
@@ -193,7 +193,7 @@ end
 
 @inline function reject_step!(W::NoiseProcess,dtnew,u,p)
   q = dtnew/W.dt
-  if adaptive_alg(W)==:RSwM1 || adaptive_alg(W)==:RSwM2
+  if adaptive_alg(W)==:RSwM1 || adaptive_alg(W)==:RSwM2 || (adaptive_alg(W)==:RSwM3 && isempty(W.S₂))
     if isinplace(W)
       W.bridge(W.dWtilde,W,0,W.dW,q,dtnew,u,p,W.curt,W.rng)
       if W.Z != nothing
@@ -216,6 +216,19 @@ end
     if length(W.S₁) > W.maxstacksize
         W.maxstacksize = length(W.S₁)
     end
+    if adaptive_alg(W)==:RSwM3
+      cutLength = dtnew
+      if cutLength > W.rswm.discard_length
+        if W.Z == nothing
+            push!(W.S₂,(cutLength,W.dWtilde,nothing))
+        else
+            push!(W.S₂,(cutLength,W.dWtilde,W.dZtilde))
+        end
+      end
+      if length(W.S₂) > W.maxstacksize2
+        W.maxstacksize = length(W.S₂)
+      end
+    end
     if isinplace(W)
       copyto!(W.dW,W.dWtilde)
       if W.Z!=nothing
@@ -227,8 +240,7 @@ end
         W.dZ = W.dZtilde
       end
     end
-    W.dt = dtnew
-  else # RSwM3
+  else # RSwM3 and W.S₂ not empty
     if !isinplace(W)
       dttmp = zero(W.dt); W.dWtmp = zero(W.dW)
       if W.Z != nothing
@@ -273,8 +285,7 @@ end
             W.dZtilde = W.bridge(W.dZ,W,0,L₃,qM,dtM,u,p,W.curt,W.rng)
           end
         end
-        # This is a control variable so do not diff through it
-        cutLength = DiffEqBase.ODE_DEFAULT_NORM((1-qM)*dtM,W.curt)
+        cutLength = L₁-dtM
         if cutLength > W.rswm.discard_length
           if W.Z == nothing
             push!(W.S₁,(cutLength,L₂-W.dWtilde,nothing))
@@ -285,7 +296,7 @@ end
         if length(W.S₁) > W.maxstacksize
           W.maxstacksize = length(W.S₁)
         end
-        cutLength = DiffEqBase.ODE_DEFAULT_NORM(qM*dtM,W.curt)
+        cutLength = dtM
         if cutLength > W.rswm.discard_length
           if W.Z == nothing
             push!(W.S₂,(cutLength,W.dWtilde,nothing))
@@ -294,7 +305,7 @@ end
           end
         end
         if length(W.S₂) > W.maxstacksize2
-            W.maxstacksize = length(W.S₂)
+          W.maxstacksize = length(W.S₂)
         end
         break
       end
@@ -310,8 +321,8 @@ end
         W.dZ += W.dZtilde - W.dZtmp
       end
     end
-    W.dt = dtnew
   end
+  W.dt = dtnew
   return nothing
 end
 

--- a/src/noise_interfaces/noise_process_interface.jl
+++ b/src/noise_interfaces/noise_process_interface.jl
@@ -272,7 +272,7 @@ end
       if dttmp < (1-q)*W.dt #while the backwards movement is less than chop off
         push!(W.S₁,(L₁,L₂,L₃))
       else
-        dtM = (q-1)*W.dt + dttmp + L₁
+        dtM = (q-1)*W.dt + dttmp
         qM = dtM/L₁
         if isinplace(W)
           W.bridge(W.dWtilde,W,0,L₂,qM,dtM,u,p,W.curt,W.rng)


### PR DESCRIPTION
While studying the RSwM3 algorithm, I noticed an issue that might be subtle (or even unmeasurable) in practical applications but should still be considered carefully to guarantee correctness.
In the rejection branch (i.e. when q < 1), the bridge theorem might be applied to the wrong interval. If there are multiple segments on the stack S2 until the desired new timestep q*h is reached, bottom elements of S2 might be lost (or rather buried) due to using this wrong interval. To fix this, one should only consider the appropriate element of S2 and split it accordingly. I have attached an image that illustrates this problem.

This pull request fixes this issue by changing the RSwM3 rejection algorithm to only consider the relevant element for the application of the bridge theorem. I have also attached a pdf with pseudocode of the currently implemented situation and a new algorithm that would implemented by this pull request.

Notably, the unit tests in `test/bridge_test.jl` still pass. However, they might not have been accurate enough to catch this problem in the first place.

Admittedly, I am not that familiar with Julia, so there might still be issues concerning the programming style.


[RSwM3_correctness.pdf](https://github.com/SciML/DiffEqNoiseProcess.jl/files/5835427/RSwM3_correctness.pdf)
[figure.pdf](https://github.com/SciML/DiffEqNoiseProcess.jl/files/5835428/figure.pdf)
