### PR TITLE
Box Wedge Tail method

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,9 @@ version = "5.5.2"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 PoissonRandom = "e409e4f3-bfea-5376-8464-e040bb5c01ab"
+QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Random123 = "74087812-796a-5b5d-8853-05524746bad3"
 RandomNumbers = "e6cf234a-135c-5ec9-84dd-332b85af5143"
@@ -32,6 +34,7 @@ StaticArrays = "0.10, 0.11, 0.12, 1.0"
 julia = "1.3"
 
 [extras]
+Cubature = "667455a9-e2ce-5579-9412-b964f529a492"
 DiffEqProblemLibrary = "a077e3f3-b75c-5d7f-a0c6-6bc4c8ec64a9"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 HypothesisTests = "09f84164-cd44-5f33-b23f-e6b0d136a0d5"
@@ -41,4 +44,4 @@ StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "DiffEqProblemLibrary", "StatsBase", "StaticArrays", "StochasticDiffEq", "Distributions", "HypothesisTests"]
+test = ["Test", "DiffEqProblemLibrary", "StatsBase", "StaticArrays", "StochasticDiffEq", "Distributions", "HypothesisTests", "Cubature"]

--- a/src/DiffEqNoiseProcess.jl
+++ b/src/DiffEqNoiseProcess.jl
@@ -13,6 +13,8 @@ import DiffEqBase: isinplace, solve, AbstractNoiseProcess,
 
 import PoissonRandom, Distributions
 
+import QuadGK, Optim
+
 using DiffEqBase: @..
 
 include("init.jl")
@@ -31,6 +33,7 @@ include("noise_interfaces/virtual_brownian_tree_interface.jl")
 include("noise_interfaces/noise_grid_interface.jl")
 include("noise_interfaces/noise_approximation_interface.jl")
 include("noise_interfaces/noise_wrapper_interface.jl")
+include("noise_interfaces/box_wedge_tail_interface.jl")
 include("noise_interfaces/common.jl")
 include("correlated_noisefunc.jl")
 
@@ -57,6 +60,8 @@ export OrnsteinUhlenbeckProcess, OrnsteinUhlenbeckProcess!
 export NoiseWrapper, NoiseFunction, NoiseGrid, NoiseApproximation
 
 export VirtualBrownianTree, VirtualBrownianTree!
+
+export BoxWedgeTail, BoxWedgeTail!
 
 export accept_step!, reject_step!, calculate_step!, setup_next_step!, save_noise!
 

--- a/src/noise_interfaces/box_wedge_tail_interface.jl
+++ b/src/noise_interfaces/box_wedge_tail_interface.jl
@@ -1,0 +1,793 @@
+function save_noise!(W::BoxWedgeTail)
+  if W.t != W.curt
+    push!(W.W,copy(W.curW))
+    push!(W.t,copy(W.curt))
+    push!(W.A,copy(W.curA))
+    if W.Z != nothing
+      push!(W.Z,copy(W.curZ))
+    end
+  end
+  return nothing
+end
+
+@inline function accept_step!(W::BoxWedgeTail,dt,u,p,setup_next=true)
+
+  W.curt += W.dt
+  W.iter += 1
+
+  if isinplace(W)
+    @.. W.curW += W.dW
+    if W.Z != nothing
+      @.. W.curZ += W.dZ
+    end
+  else
+    W.curW += W.dW
+    if W.Z != nothing
+      W.curZ += W.dZ
+    end
+  end
+
+  if W.save_everystep
+    push!(W.W,copy(W.curW))
+    push!(W.t,copy(W.curt))
+    push!(W.A,copy(W.curA))
+    if W.Z != nothing
+      push!(W.Z,copy(W.curZ))
+    end
+  end
+
+  W.dt = dt #dtpropose
+  # Setup next step
+  if setup_next
+    setup_next_step!(W::BoxWedgeTail,u,p)
+  end
+  return nothing
+end
+
+@inline function setup_next_step!(W::BoxWedgeTail,u,p)
+  calculate_step!(W,W.dt,u,p)
+  return nothing
+end
+
+@inline function calculate_step!(W::BoxWedgeTail,dt,u,p)
+  if isinplace(W)
+    sample_distribution(W.dW,W.curA,W,dt,u,p,W.curt,W.rng)
+    if W.Z != nothing
+      W.dist(W.dZ,W,dt,u,p,W.curt,W.rng)
+    end
+  else
+    W.dW, W.curA = sample_distribution(W,dt,u,p,W.curt,W.rng)
+    if W.Z != nothing
+      W.dZ = W.dist(W,dt,u,p,W.curt,W.rng)
+    end
+  end
+  W.dt = dt
+  return nothing
+end
+
+@inline function reject_step!(W::BoxWedgeTail,dtnew,u,p)
+  error("BoxWedgeTail cannot be used with adaptivity rejections")
+end
+
+@inline function interpolate!(W::BoxWedgeTail,u,p,t)
+  if sign(W.dt)*t > sign(W.dt)*W.t[end] # Steps past W
+    dt = t - W.t[end]
+    if isinplace(W)
+      sample_distribution(W.dW,W.curA,W,dt,u,p,t,W.rng)
+      W.curW .+= W.dW
+      if W.Z != nothing
+        W.dist(W.dZ,W,dt,u,p,t,W.rng)
+        W.curZ .+= W.dZ
+      end
+    else
+      W.dW = sample_distribution(W.curA,W,dt,u,p,t,W.rng)
+      W.curW += W.dW
+      if W.Z != nothing
+        W.dZ = W.dist(W,dt,u,p,t,W.rng)
+        W.curZ += W.dZ
+      end
+    end
+    out1 = copy(W.curW)
+    if W.save_everystep
+      push!(W.t,t)
+      push!(W.W,out1)
+    end
+    if W.Z != nothing
+      out2= copy(W.curZ)
+      if W.save_everystep
+        push!(W.Z,out2)
+      end
+    else
+      out2 = nothing
+    end
+    return out1,out2
+  else # Bridge
+    i = searchsortedfirst(W.t,t)
+    if t == W.t[i]
+      if isinplace(W)
+        W.curW .= W.W[i]
+      else
+        W.curW = W.W[i]
+      end
+      if W.Z != nothing
+        if isinplace(W)
+          W.curZ .= W.Z[i]
+        else
+          W.curZ = W.Z[i]
+        end
+        return copy(W.curW),copy(W.curZ)
+      else
+        return copy(W.curW),nothing
+      end
+    else
+      W0,Wh = W.W[i-1],W.W[i]
+      if W.Z != nothing
+        Z0,Zh = W.Z[i-1],W.Z[i]
+      end
+      h = W.t[i]-W.t[i-1]
+      q = (t-W.t[i-1])/h
+      if isinplace(W)
+        new_curW = similar(W.dW)
+        W.bridge(new_curW,W,W0,Wh,q,h,u,p,t,W.rng)
+        if iscontinuous(W)
+          @. new_curW += (1-q)*W0
+        else
+          @. new_curW += W0
+        end
+        if W.Z != nothing
+          new_curZ = similar(W.dZ)
+          W.bridge(new_curZ,W,Z0,Zh,q,h,u,p,t,W.rng)
+          if iscontinuous(W)
+            @. new_curZ += (1-q)*Z0
+          else
+            @. new_curZ += Z0
+          end
+        else
+          new_curZ = nothing
+        end
+      else
+        new_curW = W.bridge(W,W0,Wh,q,h,u,p,t,W.rng)
+        if iscontinuous(W)
+          # This should actually be based on the function for computing the mean
+          # flow of the noise process, but for now we'll just handle Wiener and
+          # Poisson
+          new_curW += (1-q)*W0
+        else
+          new_curW += W0
+        end
+        if W.Z != nothing
+          new_curZ = W.bridge(W,Z0,Zh,q,h,u,p,t,W.rng)
+          if iscontinuous(W)
+            new_curZ += (1-q)*Z0
+          else
+            new_curZ += Z0
+          end
+        else
+          new_curZ = nothing
+        end
+      end
+      W.curW = new_curW
+      if W.save_everystep
+        insert!(W.W,i,new_curW)
+        insert!(W.t,i,t)
+      end
+      if W.Z != nothing
+        W.curZ = new_curZ
+        if W.save_everystep
+          insert!(W.Z,i,new_curZ)
+        end
+      end
+      return new_curW,new_curZ
+    end
+  end
+end
+
+@inline function interpolate!(out1,out2,W::BoxWedgeTail,u,p,t)
+  if sign(W.dt)*t > sign(W.dt)*W.t[end] # Steps past W
+    dt = t - W.t[end]
+    sample_distribution(W.dW,W.curA,W,dt,u,p,t,W.rng)
+    out1 .+= W.dW
+    if W.Z != nothing
+      W.dist(W.dZ,W,dt,u,p,t,W.rng)
+      out2 .+= W.dZ
+    end
+    if W.save_everystep
+      push!(W.t,t)
+      push!(W.W,copy(out1))
+      if W.Z != nothing
+        push!(W.Z,copy(out2))
+      end
+    end
+  else # Bridge
+    i = searchsortedfirst(W.t,t)
+    if t == W.t[i]
+      out1 .= W.W[i]
+      if W.Z != nothing
+        out2 .= W.Z[i]
+      end
+    else
+      W0,Wh = W.W[i-1],W.W[i]
+      if W.Z != nothing
+        Z0,Zh = W.Z[i-1],W.Z[i]
+      end
+      h = W.t[i]-W.t[i-1]
+      q = (t-W.t[i-1])/h
+      W.bridge(out1,W,W0,Wh,q,h,u,p,t,W.rng)
+      out1 .+= (1-q)*W0
+      if W.Z != nothing
+        W.bridge(out2,W,Z0,Zh,q,h,u,p,t,W.rng)
+        out2 .+= (1-q)*Z0
+      end
+      W.curW .= out1
+      if W.save_everystep
+        insert!(W.W,i,copy(out1))
+        insert!(W.t,i,t)
+      end
+      if W.Z != nothing
+        W.curZ .= out2
+        if W.save_everystep
+          insert!(W.Z,i,copy(out2))
+        end
+      end
+    end
+  end
+end
+
+# joint probability densitity function
+function joint_density_function(r,a,rtol)
+  integral, err = QuadGK.quadgk(x ->r/π*(x/sinh(x))*exp(-r^2*x/(2*tanh(x)))*cos(a*x), 0, Inf, rtol=rtol)
+  return integral
+end
+
+# boxes
+abstract type AbstractBoxGeneration end
+
+mutable struct BoxGeneration1{boxesType, pType, offType, distType} <: AbstractBoxGeneration
+  boxes::boxesType
+  probability::pType
+  offset::offType
+  dist::distType
+end
+
+struct BoxGeneration2{boxesType, pType, offType, distType} <: AbstractBoxGeneration
+  boxes::boxesType
+  probability::pType
+  offset::offType
+  dist::distType
+end
+
+struct BoxGeneration3{boxesType, pType, offType, distType} <: AbstractBoxGeneration
+  boxes::boxesType
+  probability::pType
+  offset::offType
+  dist::distType
+end
+
+function generate_boxes1(densf, Δr, Δa, Δz, rM, aM, offset=nothing, scale=1)
+  boxes = Array{typeof(Δr),1}[]
+  probability = Vector{typeof(Δr)}(undef, 0)
+  rs = collect(zero(rM):Δr:rM)
+  as = collect(zero(aM):Δa:aM)
+
+  if offset===nothing
+    offset = zeros(typeof(Δr), Int(rM/Δr), Int(aM/Δa))
+  end
+
+  for (i,r) in enumerate(rs[1:end-1])
+    for (j,a) in enumerate(as[1:end-1])
+      # height of the box
+      z = Δz
+      if offset !== nothing
+        indx1 = (i-1)*scale+one(scale)
+        indx2 = (j-1)*scale+one(scale)
+        z += offset[indx1,indx2]
+      end
+
+      counter = 0
+
+      # check for complete inclusion of box in volume
+      while (z <= densf(r,a) && z <= densf(r+Δr,a) && z <= densf(r,a+Δa) && z <= densf(r+Δr,a+Δa))
+        counter += one(counter)
+        z += Δz
+      end
+      z -= Δz
+      # store position of top corner of box and width
+      if counter != 0
+        if offset !== nothing
+          push!(boxes, [r, a, z, offset[indx1,indx2]])
+        else
+          push!(boxes, [r, a, z, zero(z)])
+        end
+        push!(probability, counter*2*Δr*Δa*Δz)
+      end
+
+      if offset !== nothing
+        offset[indx1:indx1+(scale-one(scale)),indx2:indx2+(scale-one(scale))] .= z
+      end
+
+    end
+  end
+  return boxes, probability, offset
+end
+
+function generate_boxes2(densf, Δrmin, Δamin, Δzmin, Δrmax, Δamax, Δzmax, rM, aM, offset=nothing)
+  boxes = Array{typeof(Δrmin),1}[]
+  probability = Vector{typeof(Δrmin)}(undef, 0)
+  # start with largest possible size, then subsequently decrease size and fill remaining space
+  Δr = Δrmax
+  Δa = Δamax
+  Δz = Δzmax
+
+  if offset===nothing
+    offset = zeros(typeof(Δrmin), Int(rM/Δrmin), Int(aM/Δamin))
+  end
+
+  while (Δr >= Δrmin && Δa >= Δamin && Δz >= Δzmin)
+    scale = Int(Δr/Δrmin)
+    boxestmp, probabilitytmp = generate_boxes1(densf, Δr, Δa, Δz, rM, aM, offset, scale)
+    boxes = cat(boxes, boxestmp, dims=1)
+    probability = cat(probability, probabilitytmp, dims=1)
+    Δr = Δr/2
+    Δa = Δa/2
+    Δz = Δz/2
+  end
+  # merge boxes
+  return boxes, probability, offset
+end
+
+function generate_boxes3(densf, Δr, Δa, Δz, rM, aM, offset=nothing, scale=1)
+  boxes = Array{typeof(Δr),1}[]
+  probability = Vector{typeof(Δr)}(undef, 0)
+  rs = collect(zero(rM):Δr:rM)
+  as = collect(zero(aM):Δa:aM)
+
+  if offset===nothing
+    offset = zeros(typeof(Δr), Int(rM/Δr), Int(aM/Δa))
+  end
+
+  for (i,r) in enumerate(rs[1:end-1])
+    for (j,a) in enumerate(as[1:end-1])
+      # height of the box
+      z = Δz
+      if offset !== nothing
+        indx1 = (i-1)*scale+one(scale)
+        indx2 = (j-1)*scale+one(scale)
+        z += offset[indx1,indx2]
+      end
+      # check for complete inclusion of box in volume
+      while (z <= densf(r,a) && z <= densf(r+Δr,a) && z <= densf(r,a+Δa) && z <= densf(r+Δr,a+Δa))
+        # store position of top corner of box and width
+        push!(boxes, [r, a, z, z-Δz])
+        # probability = 2*Δr*Δa*Δz for all small boxes, push!(probability, 1)
+        push!(probability, 2*Δr*Δa*Δz)
+
+        z += Δz
+      end
+      z -= Δz
+      if offset !== nothing
+        offset[indx1:indx1+(scale-one(scale)),indx2:indx2+(scale-one(scale))] .= z
+      end
+    end
+  end
+  return boxes, probability, offset
+end
+
+
+# entropy of partition
+function entropy(probs)
+  TotalVolume = sum(probs)
+  qi = probs./TotalVolume
+  return - sum(qi.*log2.(qi))
+end
+
+
+# sampling from boxes
+function sample_box(W::BoxWedgeTail, Boxes::AbstractBoxGeneration)
+  indx = rand(W.rng, Boxes.dist)
+  # boxes store r, a, z, offset[indx1,indx2]
+  ri, ai, _, _ = Boxes.boxes[indx]
+  DU = Distributions.Product(Distributions.Uniform.([ri,ai],[ri+W.Δr,ai+W.Δa]))
+
+  r, a = rand(W.rng, DU)
+  return r,a
+end
+
+
+# Wedges
+struct Wedges{boxesType, pType, offType, distType} <: AbstractBoxGeneration
+  boxes::boxesType
+  probability::pType
+  fvalues::offType
+  dist::distType
+end
+
+# linear approximation for squeezing method
+function linear_interpolation_wedges(fij, fij2, fij3, fij4, r, a, ri, ai, Δr, Δa)
+  t = (r - ri)/Δr
+  u = (a - ai)/Δa
+  return (one(t)-t)*(one(u)-u)*fij + t*(one(u)-u)*fij2 + (one(t)-t)*u*fij3 + t*u*fij4
+end
+
+function contrained_optimization_problem(densf, fij, fij2, fij3, fij4, ri, ai, Δr, Δa)
+  function difference(x)
+    densf(x[1], x[2]) - linear_interpolation_wedges(fij, fij2, fij3, fij4, x[1], x[2], ri, ai, Δr, Δa)
+  end
+  ϵijmax = Optim.optimize(x->-difference(x), [ri, ai], [ri+Δr, ai+Δa], [ri+Δr/2, ai+Δa/2], Optim.Fminbox(Optim.NelderMead()))
+  ϵijmin = Optim.optimize(x-> difference(x), [ri, ai], [ri+Δr, ai+Δa], [ri+Δr/2, ai+Δa/2], Optim.Fminbox(Optim.NelderMead()))
+  return ϵijmin.minimum, ϵijmax.minimum
+end
+
+function generate_wedges(densf, Δr, Δa, Δz, rM, aM, offset, sqeezing)
+  boxes = Array{typeof(Δr),1}[]
+  probability = Vector{typeof(Δr)}(undef, 0)
+  f = Array{typeof(Δr),1}[]
+  rs = collect(zero(rM):Δr:rM)
+  as = collect(zero(aM):Δa:aM)
+  for (i,r) in enumerate(rs[1:end-1])
+    for (j,a) in enumerate(as[1:end-1])
+      # base height hij of the box enclosing the wedge
+      hij = offset[i,j]
+      # max height of the box f̃_ij
+      fij = densf(r,a) # f_{ij}
+      fij2 = densf(r+Δr,a) # f_{i+1,j}
+      fij3 = densf(r,a+Δa) # f_{i,j+1}
+      fij4 = densf(r+Δr,a+Δa) # f_{i+1,j+1}
+
+      f̃ij = max(fij,fij2,fij3,fij4)
+
+      # store position of top corner of box and width
+      if sqeezing
+        ϵijmin, ϵijmax = contrained_optimization_problem(densf, fij, fij2, fij3, fij4, r, a, Δr, Δa)
+        push!(boxes, [f̃ij, hij, abs(ϵijmin), abs(ϵijmax), r, a])
+        # store PDF values
+        push!(f, [fij, fij2, fij3, fij4])
+      else
+        push!(boxes, [f̃ij, hij, zero(hij), zero(hij), r, a])
+      end
+
+      # probability = 2*Δr*Δa*Δz
+      push!(probability, 2*Δr*Δa*(f̃ij-hij))
+    end
+  end
+  return boxes, probability, f
+end
+
+
+# sampling from wedges (TODO inplace)
+function sample_wedge(W::BoxWedgeTail, wedges::Wedges)
+  indx = rand(W.rng, wedges.dist)
+  # wedges store f̃ij, hij, ϵijmin, ϵijmax, r, a, Δr
+  f̃ij, hij, ϵijmin, ϵijmax, ri, ai = wedges.boxes[indx]
+  DU = Distributions.Product(Distributions.Uniform.([ri,ai,hij],[ri+W.Δr,ai+W.Δa,f̃ij]))
+  if W.sqeezing
+    fij, fij2, fij3, fij4 = wedges.fvalues[indx]
+    while true
+      r, a, z = rand(W.rng, DU)
+      flin = linear_interpolation_wedges(fij, fij2, fij3, fij4, r, a, ri, ai, W.Δr, W.Δa)
+      if z > flin + ϵijmax
+        continue
+      elseif z < flin - ϵijmin
+        break
+      end
+
+      if z <= W.jpdf(r,a)
+        break
+      end
+    end
+  else
+    r, a, z = rand(W.rng, DU)
+    while z > W.jpdf(r,a)
+      r, a, z = rand(W.rng, DU)
+    end
+  end
+  return r, a
+end
+
+
+# Tail approximation
+abstract type AbstractTail end
+
+struct Tail1{pType, distType, pdfType, cType} <: AbstractTail
+  p::pType
+  dist::distType
+  candpdf::pdfType
+  cvalue::cType # success probability 1/c.
+
+  function Tail1(rM, aM)
+    p = convert(typeof(rM),0.0002982405821953734)
+    candpdf = (r,a) -> exp(-r^2/2)
+    dist1 = Distributions.truncated(Distributions.Normal(zero(rM), one(rM)), rM, 12*one(rM))
+    dist2 = Distributions.Uniform(zero(aM), aM)
+
+    dist = Distributions.Product([dist1,dist2])
+
+    c = convert(typeof(rM),2.3)
+
+    new{typeof(p),typeof(dist),typeof(candpdf),typeof(c)}(p,dist,candpdf,c)
+  end
+end
+
+struct Tail2{pType, distType, pdfType, cType, boundsType} <: AbstractTail
+  p::pType
+  dist::distType
+  candpdf::pdfType
+  cvalue::cType # success probability 1/c.
+  alower::boundsType
+  aupper::boundsType
+
+  function Tail2(rM, aM)
+    p = convert(typeof(rM),3.648002197730662e-5)
+    candpdf = (r,a) -> 3//2*exp(-r^2/2-3*a^2/(2*r^2))
+    # store only distribution of r, when sampling re-create distribution for a|r
+    dist = Distributions.truncated(Distributions.Normal(zero(rM), one(rM)), rM, 8*one(rM))
+
+    c = convert(typeof(rM),2.0)
+
+    alower = aM
+    aupper = 2*aM
+
+    new{typeof(p),typeof(dist),typeof(candpdf),typeof(c),typeof(alower)}(p,dist,candpdf,c,alower,aupper)
+  end
+end
+
+struct Tail3{pType, distType, pdfType, cType} <: AbstractTail
+  p::pType
+  dist::distType
+  candpdf::pdfType
+  cvalue::cType # success probability 1/c.
+
+  function Tail3(rM, aM)
+    p = convert(typeof(rM),0.0018026889941638695)
+    candpdf = (r,a) -> exp(convert(typeof(rM),-pi/2)*a)
+    dist1 = Distributions.Uniform(2*one(rM), rM)
+    dist2 = Distributions.truncated(Distributions.Exponential(convert(typeof(rM),2/pi)), aM, 8*one(aM))
+
+    dist = Distributions.Product([dist1,dist2])
+
+    c = convert(typeof(rM),2.6)
+
+    new{typeof(p),typeof(dist),typeof(candpdf),typeof(c)}(p,dist,candpdf,c)
+  end
+end
+
+struct Tail4{pType, distType, pdfType, cType} <: AbstractTail
+  p::pType
+  dist::distType
+  candpdf::pdfType
+  cvalue::cType # success probability 1/c.
+
+  function Tail4(rM, aM)
+    p = convert(typeof(rM),1.6145323459108908e-6)
+    candpdf = (r,a) -> 15*r*exp(convert(typeof(rM),-pi)*a)
+    dist1 = Distributions.TriangularDist(zero(rM), one(rM)/2, one(rM)/2)
+    dist2 = Distributions.truncated(Distributions.Exponential(convert(typeof(rM),1/pi)), aM, 6*one(aM))
+
+    dist = Distributions.Product([dist1,dist2])
+
+    c = convert(typeof(rM),2.6)
+
+    new{typeof(p),typeof(dist),typeof(candpdf),typeof(c)}(p,dist,candpdf,c)
+  end
+end
+
+struct Tail5{pType, distType, pdfType, cType} <: AbstractTail
+  p::pType
+  dist::distType
+  candpdf::pdfType
+  cvalue::cType # success probability 1/c.
+
+  function Tail5(rM, aM)
+    p = convert(typeof(rM),1.9637270929071978e-5)
+    candpdf = (r,a) -> 15*r*exp(convert(typeof(rM),-2.8)*a)
+    dist1 = Distributions.TriangularDist(one(rM)/2, one(rM), one(rM))
+    dist2 = Distributions.truncated(Distributions.Exponential(convert(typeof(rM),1/2.8)), aM, 6*one(aM))
+
+    dist = Distributions.Product([dist1,dist2])
+
+    c = convert(typeof(rM),2.8)
+
+    new{typeof(p),typeof(dist),typeof(candpdf),typeof(c)}(p,dist,candpdf,c)
+  end
+end
+
+struct Tail6{pType, distType, pdfType, cType} <: AbstractTail
+  p::pType
+  dist::distType
+  candpdf::pdfType
+  cvalue::cType # success probability 1/c.
+
+  function Tail6(rM, aM)
+    p = convert(typeof(rM),0.00012022274714710923)
+    candpdf = (r,a) -> 25*r*exp(convert(typeof(rM),-2.6)*a)
+    dist1 = Distributions.TriangularDist(one(rM), 3/2*one(rM), 3/2*one(rM))
+    dist2 = Distributions.truncated(Distributions.Exponential(convert(typeof(rM),1/2.6)), aM, 6*one(aM))
+
+    dist = Distributions.Product([dist1,dist2])
+
+    c = convert(typeof(rM),3.0)
+
+    new{typeof(p),typeof(dist),typeof(candpdf),typeof(c)}(p,dist,candpdf,c)
+  end
+end
+
+struct Tail7{pType, distType, pdfType, cType} <: AbstractTail
+  p::pType
+  dist::distType
+  candpdf::pdfType
+  cvalue::cType # success probability 1/c.
+
+  function Tail7(rM, aM)
+    p = convert(typeof(rM),0.00038595770876898326)
+    candpdf = (r,a) -> 25*r*exp(convert(typeof(rM),-2.4)*a)
+    dist1 = Distributions.TriangularDist(3/2*one(rM), 2*one(rM), 2*one(rM))
+    dist2 = Distributions.truncated(Distributions.Exponential(convert(typeof(rM),1/2.4)), aM, 6*one(aM))
+
+    dist = Distributions.Product([dist1,dist2])
+
+    c = convert(typeof(rM),3.2)
+
+    new{typeof(p),typeof(dist),typeof(candpdf),typeof(c)}(p,dist,candpdf,c)
+  end
+end
+
+struct Tail8{pType, distType, pdfType, cType} <: AbstractTail
+  p::pType
+  dist::distType
+  candpdf::pdfType
+  cvalue::cType # success probability 1/c.
+
+  function Tail8(rM, aM)
+    p = convert(typeof(rM),6.566973361922312e-6)
+    candpdf = (r,a) -> 40*r*exp(convert(typeof(rM),-2.4)*a)
+    dist1 = Distributions.TriangularDist(one(rM), 2*one(rM), 2*one(rM))
+    dist2 = Distributions.truncated(Distributions.Exponential(convert(typeof(rM),1/2.4)), 6*one(aM), 8*one(aM))
+
+    dist = Distributions.Product([dist1,dist2])
+
+    c = convert(typeof(rM),4.2)
+
+    new{typeof(p),typeof(dist),typeof(candpdf),typeof(c)}(p,dist,candpdf,c)
+  end
+end
+
+struct Tail9{pType, distType, pdfType, cType} <: AbstractTail
+  p::pType
+  dist::distType
+  candpdf::pdfType
+  cvalue::cType # success probability 1/c.
+
+  function Tail9(rM, aM)
+    p = convert(typeof(rM),4.149989421681627e-6)
+    candpdf = (r,a) -> 7//10*exp(convert(typeof(rM),-pi/2)*a)
+    dist1 = Distributions.Uniform(2*one(rM), 5*one(rM))
+    dist2 = Distributions.truncated(Distributions.Exponential(convert(typeof(rM),2/pi)), 8*one(aM), 10*one(aM))
+
+    dist = Distributions.Product([dist1,dist2])
+
+    c = convert(typeof(rM),2.4)
+
+    new{typeof(p),typeof(dist),typeof(candpdf),typeof(c)}(p,dist,candpdf,c)
+  end
+end
+
+struct TailApproxs{T1<:Tail1,T2<:Tail2,T3<:Tail3,T4<:Tail4,T5<:Tail5,T6<:Tail6,
+    T7<:Tail7,T8<:Tail8,T9<:Tail9,distType}
+  tail1::T1
+  tail2::T2
+  tail3::T3
+  tail4::T4
+  tail5::T5
+  tail6::T6
+  tail7::T7
+  tail8::T8
+  tail9::T9
+  dist::distType
+
+  function TailApproxs(rM, aM)
+    tail1 = Tail1(rM, aM)
+    tail2 = Tail2(rM, aM)
+    tail3 = Tail3(rM, aM)
+    tail4 = Tail4(rM, aM)
+    tail5 = Tail5(rM, aM)
+    tail6 = Tail6(rM, aM)
+    tail7 = Tail7(rM, aM)
+    tail8 = Tail8(rM, aM)
+    tail9 = Tail9(rM, aM)
+
+    probability = [tail1.p,tail2.p,tail3.p,tail4.p,tail5.p,tail6.p,tail7.p,tail8.p,tail9.p]
+
+    dist = Distributions.Categorical(probability/sum(probability))
+
+    new{typeof(tail1),typeof(tail2),typeof(tail3),typeof(tail4),typeof(tail5),
+      typeof(tail6),typeof(tail7),typeof(tail8),typeof(tail9),typeof(dist)}(tail1,tail2,
+      tail3,tail4,tail5,tail6,tail7,tail8,tail9,dist)
+  end
+end
+
+# sampling from tail approximations by rejection sampling
+function sample_tail(W::BoxWedgeTail, tails::TailApproxs)
+  indx = rand(W.rng, tails.dist)
+  # decide from which tail region to sample
+  if index == 1
+    T = tails.tail1
+  elseif index == 2
+    T = tails.tail2
+  elseif index == 3
+    T = tails.tail3
+  elseif index == 4
+    T = tails.tail4
+  elseif index == 5
+    T = tails.tail5
+  elseif index == 6
+    T = tails.tail6
+  elseif index == 7
+    T = tails.tail7
+  elseif index == 8
+    T = tails.tail8
+  else
+    T = tails.tail9
+  end
+
+  r, a = sample_tail(W.rng, W.jpdf, T)
+end
+
+function sample_tail(rng, densf, T::Tail2)
+
+  local r,a
+
+  while true
+    # draw uniform
+    U = rand(rng)
+    # draw a candidate X∼g from the candidate density
+    # draw first the r value
+    r = rand(rng, T.dist)
+    # generate a from the conditional distribution
+    dista = Distributions.truncated(Distributions.Normal(zero(r), sqrt(r/3)), T.alower, T.aupper)
+    a = rand(rng, dista)
+    if U <= densf(r,a)/(T.cvalue*T.candpdf(r,a))
+      break
+    end
+  end
+
+  return r,a
+end
+
+function sample_tail(rng, densf, T)
+  local r, a
+  while true
+    # draw uniform
+    U = rand(rng)
+    # draw a candidate X∼g from the candidate density
+    r,a = rand(rng, T.dist)
+    if U <= densf(r,a)/(T.cvalue*T.candpdf(r,a))
+      break
+    end
+  end
+
+  return r,a
+end
+
+
+function sample_distribution(dW,curA,W::BoxWedgeTail,dt,u,p,t,rng)
+  # decide if sample should come from boxes, wedges, or tails
+
+  # get (r,a) pair
+
+  # get dWs from r
+
+  # scale by dt
+
+  return nothing
+end
+
+function sample_distribution(W::BoxWedgeTail,dt,u,p,t,rng)
+  # decide if sample should come from boxes, wedges, or tails
+
+  # get (r,a) pair
+
+  # get dWs from r
+
+  # scale by dt
+
+  return dW, A
+end

--- a/src/wiener.jl
+++ b/src/wiener.jl
@@ -91,7 +91,6 @@ RealWienerProcess(t0,W0,Z0=nothing;kwargs...) = NoiseProcess{false}(t0,W0,Z0,REA
 function REAL_INPLACE_WHITE_NOISE_DIST(rand_vec,W,dt,u,p,t,rng)
   sqabsdt = @fastmath sqrt(abs(dt))
   wiener_randn!(rng,rand_vec)
-  sqabsdt = sqrt(abs(dt))
   @.. rand_vec *= sqabsdt
 end
 function REAL_INPLACE_WHITE_NOISE_BRIDGE(rand_vec,W,W0,Wh,q,h,u,p,t,rng)

--- a/test/BWT_test.jl
+++ b/test/BWT_test.jl
@@ -1,0 +1,163 @@
+#@testset "BoxWedgeTail tests" begin
+
+using DiffEqNoiseProcess, Test, Random
+import Distributions
+using Cubature
+using Statistics
+
+# Test generation of boxes
+W = BoxWedgeTail(0.0,zeros(2), box_grouping = :Columns)
+# number of boxes with column-wise packing
+@test length(W.boxes.boxes) == 2894
+@test sum(W.boxes.probability) ≈ 0.911857 rtol=1e-5
+@test DiffEqNoiseProcess.entropy(W.boxes.probability) ≈ 10.13 rtol=1e-5
+
+
+W = BoxWedgeTail(0.0,zeros(2), box_grouping = :none)
+# number of boxes of smallest size
+@test length(W.boxes.boxes) == 119519
+@test minimum(2*W.Δr*W.Δa*W.Δz .== W.boxes.probability)
+@test sum(W.boxes.probability) ≈ 0.911857 rtol=1e-5
+@test DiffEqNoiseProcess.entropy(W.boxes.probability) ≈ Distributions.entropy(W.boxes.dist,2) rtol=1e-5
+
+W = BoxWedgeTail(0.0,zeros(2), box_grouping = :MinEntropy)
+# number of boxes with min-entropy packing
+@test length(W.boxes.boxes) == 2975
+@test sum(W.boxes.probability) ≈ 0.911857 rtol=1e-5
+@test DiffEqNoiseProcess.entropy(W.boxes.probability) ≈ 7.14 rtol=1e-3
+
+# test generation of wedges
+
+(val,err) = hcubature(x-> W.jpdf(x[1],x[2]), [zero(W.rM),zero(W.aM)],  [W.rM,W.aM])
+@test 2*val ≈ 0.99732 rtol=1e-5
+
+# number of columns
+@test (W.aM/W.Δa) * (W.rM/W.Δr) == 4096
+# probability for wedges
+@test 2*val - sum(W.boxes.probability) ≈ 0.0855 rtol=1e-3
+# on average less than half of the samples have to be rejected
+@test sum(W.wedges.probability) <= 2*(2*val - sum(W.boxes.probability))
+@test length(W.wedges.boxes) == 4096
+
+# without sqeezing method
+W = BoxWedgeTail(0.0,zeros(2), box_grouping = :MinEntropy, sqeezing=false)
+# probability for wedges
+@test 2*val - sum(W.boxes.probability) ≈ 0.0855 rtol=1e-3
+# on average less than half of the samples have to be rejected
+@test sum(W.wedges.probability) <= 2*(2*val - sum(W.boxes.probability))
+@test length(W.wedges.boxes) == 4096
+
+# check probabilities for tail approximation
+# region 1
+val1, _ = hcubature(x->W.jpdf(x[1],x[2]), [W.rM,zero(W.aM)], [12*one(W.rM),W.aM])
+@test 2*val1 ≈ 2.98*1e-4 rtol=1e-3
+@test W.tails.tail1.p ≈ 2*val1 rtol=1e-10
+# region 2
+val2, _ = hcubature(x->W.jpdf(x[1],x[2]), [W.rM,W.aM], [8*one(W.rM),8*one(W.aM)])
+@test 2*val2 ≈ 3.65*1e-5 rtol=1e-3
+@test W.tails.tail2.p ≈ 2*val2 rtol=1e-10
+# region 3
+val3, _ = hcubature(x->W.jpdf(x[1],x[2]), [2*one(W.rM),W.aM], [W.rM,8*one(W.aM)])
+@test 2*val3 ≈ 1.80*1e-3 rtol=1e-2
+@test W.tails.tail3.p ≈ 2*val3 rtol=1e-10
+# region 4
+val4, _ = hcubature(x->W.jpdf(x[1],x[2]), [zero(W.rM),W.aM], [one(W.rM)/2,6*one(W.aM)])
+@test 2*val4 ≈ 1.61*1e-6 rtol=1e-2
+@test W.tails.tail4.p ≈ 2*val4 rtol=1e-10
+# region 5
+val5, _ = hcubature(x->W.jpdf(x[1],x[2]), [one(W.rM)/2,W.aM], [one(W.rM),6*one(W.aM)])
+@test 2*val5 ≈ 1.96*1e-5 rtol=1e-2
+@test W.tails.tail5.p ≈ 2*val5 rtol=1e-10
+# region 6
+val6, _ = hcubature(x->W.jpdf(x[1],x[2]), [one(W.rM),W.aM], [3*one(W.rM)/2,6*one(W.aM)])
+@test 2*val6 ≈ 1.20*1e-4 rtol=1e-2
+@test W.tails.tail6.p ≈ 2*val6 rtol=1e-10
+# region 7
+val7, _ = hcubature(x->W.jpdf(x[1],x[2]), [3*one(W.rM)/2,W.aM], [2*one(W.rM),6*one(W.aM)])
+@test 2*val7 ≈ 3.86*1e-4 rtol=1e-3
+@test W.tails.tail7.p ≈ 2*val7 rtol=1e-10
+# region 8
+val8, _ = hcubature(x->W.jpdf(x[1],x[2]), [one(W.rM),6*one(W.aM)], [2*one(W.rM),8*one(W.aM)])
+@test 2*val8 ≈ 6.57*1e-6 rtol=1e-3
+@test W.tails.tail8.p ≈ 2*val8 rtol=1e-10
+# region 9
+val9, _ = hcubature(x->W.jpdf(x[1],x[2]), [2*one(W.rM),8*one(W.aM)], [5*one(W.rM),10*one(W.aM)])
+@test 2*val9 ≈ 4.15*1e-6 rtol=1e-3
+@test W.tails.tail9.p ≈ 2*val9 rtol=1e-10
+
+# test remainder
+@test 1.0-(2*(val+val1+val2+val3+val4+val5+val6+val7+val8+val9)) ≈ 3.81e-7 atol=1e-3
+
+# tests if sampling works (samples from expected domain)
+
+# boxes
+samples = [DiffEqNoiseProcess.sample_box(W, W.boxes) for i=1:100_000]
+@test minimum(getindex.(samples, 1)) > 0
+@test minimum(getindex.(samples, 2)) > 0
+@test maximum(getindex.(samples, 1)) < W.rM
+@test maximum(getindex.(samples, 2)) < W.aM
+
+# wedges
+samples = [DiffEqNoiseProcess.sample_wedge(W, W.wedges) for i=1:100_000]
+@test minimum(getindex.(samples, 1)) > 0
+@test minimum(getindex.(samples, 2)) > 0
+@test maximum(getindex.(samples, 1)) < W.rM
+@test maximum(getindex.(samples, 2)) < W.aM
+
+# tails
+samples = [DiffEqNoiseProcess.sample_tail(W.rng, W.jpdf, W.tails.tail1) for i=1:100_000]
+@test minimum(getindex.(samples, 1)) > 4
+@test minimum(getindex.(samples, 2)) > 0
+@test maximum(getindex.(samples, 1)) < 12
+@test maximum(getindex.(samples, 2)) < 4
+
+samples = [DiffEqNoiseProcess.sample_tail(W.rng, W.jpdf, W.tails.tail2) for i=1:100_000]
+@test minimum(getindex.(samples, 1)) > 4
+@test minimum(getindex.(samples, 2)) > 4
+@test maximum(getindex.(samples, 1)) < 8
+@test maximum(getindex.(samples, 2)) < 8
+
+samples = [DiffEqNoiseProcess.sample_tail(W.rng, W.jpdf, W.tails.tail3) for i=1:100_000]
+@test minimum(getindex.(samples, 1)) > 2
+@test minimum(getindex.(samples, 2)) > 4
+@test maximum(getindex.(samples, 1)) < 4
+@test maximum(getindex.(samples, 2)) < 8
+
+samples = [DiffEqNoiseProcess.sample_tail(W.rng, W.jpdf, W.tails.tail4) for i=1:100_000]
+@test minimum(getindex.(samples, 1)) > 0
+@test minimum(getindex.(samples, 2)) > 4
+@test maximum(getindex.(samples, 1)) < 0.5
+@test maximum(getindex.(samples, 2)) < 6
+
+samples = [DiffEqNoiseProcess.sample_tail(W.rng, W.jpdf, W.tails.tail5) for i=1:100_000]
+@test minimum(getindex.(samples, 1)) > 0.5
+@test minimum(getindex.(samples, 2)) > 4
+@test maximum(getindex.(samples, 1)) < 1
+@test maximum(getindex.(samples, 2)) < 6
+
+samples = [DiffEqNoiseProcess.sample_tail(W.rng, W.jpdf, W.tails.tail6) for i=1:100_000]
+@test minimum(getindex.(samples, 1)) > 1
+@test minimum(getindex.(samples, 2)) > 4
+@test maximum(getindex.(samples, 1)) < 1.5
+@test maximum(getindex.(samples, 2)) < 6
+
+samples = [DiffEqNoiseProcess.sample_tail(W.rng, W.jpdf, W.tails.tail7) for i=1:100_000]
+@test minimum(getindex.(samples, 1)) > 1.5
+@test minimum(getindex.(samples, 2)) > 4
+@test maximum(getindex.(samples, 1)) < 2
+@test maximum(getindex.(samples, 2)) < 6
+
+samples = [DiffEqNoiseProcess.sample_tail(W.rng, W.jpdf, W.tails.tail8) for i=1:100_000]
+@test minimum(getindex.(samples, 1)) > 1
+@test minimum(getindex.(samples, 2)) > 6
+@test maximum(getindex.(samples, 1)) < 2
+@test maximum(getindex.(samples, 2)) < 8
+
+samples = [DiffEqNoiseProcess.sample_tail(W.rng, W.jpdf, W.tails.tail9) for i=1:100_000]
+@test minimum(getindex.(samples, 1)) > 2
+@test minimum(getindex.(samples, 2)) > 8
+@test maximum(getindex.(samples, 1)) < 5
+@test maximum(getindex.(samples, 2)) < 10
+
+
+#end

--- a/test/BWT_test.jl
+++ b/test/BWT_test.jl
@@ -4,6 +4,7 @@ using DiffEqNoiseProcess, Test, Random
 import Distributions
 using Cubature
 using Statistics
+using DiffEqBase
 
 # Test generation of boxes
 W = BoxWedgeTail(0.0,zeros(2), box_grouping = :Columns)
@@ -88,76 +89,161 @@ val9, _ = hcubature(x->W.jpdf(x[1],x[2]), [2*one(W.rM),8*one(W.aM)], [5*one(W.rM
 # test remainder
 @test 1.0-(2*(val+val1+val2+val3+val4+val5+val6+val7+val8+val9)) ≈ 3.81e-7 atol=1e-3
 
+@test W.distBWT.p[1] ≈ 0.911857 rtol=1e-5
+@test W.distBWT.p[2] ≈ 0.0855 rtol=1e-3
+@test W.distBWT.p[3] ≈ 0.0027 rtol=1e-2
 # tests if sampling works (samples from expected domain)
 
 # boxes
-samples = [DiffEqNoiseProcess.sample_box(W, W.boxes) for i=1:100_000]
+#W = BoxWedgeTail(0.0,zeros(2), box_grouping = :MinEntropy)
+samples = [DiffEqNoiseProcess.sample_box(W, W.boxes) for i=1:1000]
 @test minimum(getindex.(samples, 1)) > 0
 @test minimum(getindex.(samples, 2)) > 0
 @test maximum(getindex.(samples, 1)) < W.rM
 @test maximum(getindex.(samples, 2)) < W.aM
+
+# using KernelDensity, StatsPlots, Plots
+# r = getindex.(samples,1)
+# a = getindex.(samples,2)
+# BKDE = kde((r, a), boundary=((0,4),(0,4)))
+# @test one(eltype(r)) ≈ sum(BKDE.density)*BKDE.x[2]*BKDE.y[2] rtol=1e-3
+# pl1 = heatmap(BKDE)
+# pl2 = marginalhist(r, a, fc = :plasma,  xlabel="r",  ylabel="a", bins=(64,64))
+# pl3 = plot(0:W.Δr:4,0:W.Δa:4,W.jpdf,st =:contourf, xlabel="r", ylabel="a", title="f(r,a)")
+# pl = plot(pl1, pl2, pl3, layout = (1, 3), legend = false, size=(800,250))
+# savefig(pl, "boxes.png")
 
 # wedges
-samples = [DiffEqNoiseProcess.sample_wedge(W, W.wedges) for i=1:100_000]
+samples = [DiffEqNoiseProcess.sample_wedge(W, W.wedges) for i=1:1_000]
 @test minimum(getindex.(samples, 1)) > 0
 @test minimum(getindex.(samples, 2)) > 0
 @test maximum(getindex.(samples, 1)) < W.rM
 @test maximum(getindex.(samples, 2)) < W.aM
 
+# r = getindex.(samples,1)
+# a = getindex.(samples,2)
+# BKDE = kde((r, a), boundary=((0,4),(0,4)))
+# @test one(eltype(r)) ≈ sum(BKDE.density)*BKDE.x[2]*BKDE.y[2] rtol=1e-3
+# pl1 = heatmap(BKDE)
+# pl2 = marginalhist(r, a, fc = :plasma,  xlabel="r",  ylabel="a", bins=(64,64))
+# pl3 = plot(0:W.Δr:4,0:W.Δa:4,W.jpdf,st =:contourf, xlabel="r", ylabel="a", title="f(r,a)")
+# pl = plot(pl1, pl2, pl3, layout = (1, 3), legend = false, size=(800,250))
+# savefig(pl, "wedges.png")
+
 # tails
-samples = [DiffEqNoiseProcess.sample_tail(W.rng, W.jpdf, W.tails.tail1) for i=1:100_000]
+# samples = [DiffEqNoiseProcess.sample_tail(W, W.tails) for i=1:100_000]
+# r = getindex.(samples,1)
+# a = getindex.(samples,2)
+# BKDE = kde((r, a), boundary=((0,12),(0,10)))
+# @test one(eltype(r)) ≈ sum(BKDE.density)*BKDE.x[2]*BKDE.y[2] rtol=1e-3
+# pl1 = heatmap(BKDE)
+# pl2 = marginalhist(r, a, fc = :plasma,  xlabel="r",  ylabel="a", bins=(64,64))
+# pl3 = plot(0:W.Δr:12,0:W.Δa:10,W.jpdf,st =:contourf, xlabel="r", ylabel="a", title="f(r,a)")
+# pl = plot(pl1, pl2, pl3, layout = (1, 3), legend = false, size=(800,250))
+# savefig(pl, "tails.png")
+
+
+samples = [DiffEqNoiseProcess.sample_tail(W.rng, W.jpdf, W.tails.tail1) for i=1:1_000]
 @test minimum(getindex.(samples, 1)) > 4
 @test minimum(getindex.(samples, 2)) > 0
 @test maximum(getindex.(samples, 1)) < 12
 @test maximum(getindex.(samples, 2)) < 4
 
-samples = [DiffEqNoiseProcess.sample_tail(W.rng, W.jpdf, W.tails.tail2) for i=1:100_000]
+samples = [DiffEqNoiseProcess.sample_tail(W.rng, W.jpdf, W.tails.tail2) for i=1:1_000]
 @test minimum(getindex.(samples, 1)) > 4
 @test minimum(getindex.(samples, 2)) > 4
 @test maximum(getindex.(samples, 1)) < 8
 @test maximum(getindex.(samples, 2)) < 8
 
-samples = [DiffEqNoiseProcess.sample_tail(W.rng, W.jpdf, W.tails.tail3) for i=1:100_000]
+samples = [DiffEqNoiseProcess.sample_tail(W.rng, W.jpdf, W.tails.tail3) for i=1:1_000]
 @test minimum(getindex.(samples, 1)) > 2
 @test minimum(getindex.(samples, 2)) > 4
 @test maximum(getindex.(samples, 1)) < 4
 @test maximum(getindex.(samples, 2)) < 8
 
-samples = [DiffEqNoiseProcess.sample_tail(W.rng, W.jpdf, W.tails.tail4) for i=1:100_000]
+samples = [DiffEqNoiseProcess.sample_tail(W.rng, W.jpdf, W.tails.tail4) for i=1:1_000]
 @test minimum(getindex.(samples, 1)) > 0
 @test minimum(getindex.(samples, 2)) > 4
 @test maximum(getindex.(samples, 1)) < 0.5
 @test maximum(getindex.(samples, 2)) < 6
 
-samples = [DiffEqNoiseProcess.sample_tail(W.rng, W.jpdf, W.tails.tail5) for i=1:100_000]
+samples = [DiffEqNoiseProcess.sample_tail(W.rng, W.jpdf, W.tails.tail5) for i=1:1_000]
 @test minimum(getindex.(samples, 1)) > 0.5
 @test minimum(getindex.(samples, 2)) > 4
 @test maximum(getindex.(samples, 1)) < 1
 @test maximum(getindex.(samples, 2)) < 6
 
-samples = [DiffEqNoiseProcess.sample_tail(W.rng, W.jpdf, W.tails.tail6) for i=1:100_000]
+samples = [DiffEqNoiseProcess.sample_tail(W.rng, W.jpdf, W.tails.tail6) for i=1:1_000]
 @test minimum(getindex.(samples, 1)) > 1
 @test minimum(getindex.(samples, 2)) > 4
 @test maximum(getindex.(samples, 1)) < 1.5
 @test maximum(getindex.(samples, 2)) < 6
 
-samples = [DiffEqNoiseProcess.sample_tail(W.rng, W.jpdf, W.tails.tail7) for i=1:100_000]
+samples = [DiffEqNoiseProcess.sample_tail(W.rng, W.jpdf, W.tails.tail7) for i=1:1_000]
 @test minimum(getindex.(samples, 1)) > 1.5
 @test minimum(getindex.(samples, 2)) > 4
 @test maximum(getindex.(samples, 1)) < 2
 @test maximum(getindex.(samples, 2)) < 6
 
-samples = [DiffEqNoiseProcess.sample_tail(W.rng, W.jpdf, W.tails.tail8) for i=1:100_000]
+samples = [DiffEqNoiseProcess.sample_tail(W.rng, W.jpdf, W.tails.tail8) for i=1:1_000]
 @test minimum(getindex.(samples, 1)) > 1
 @test minimum(getindex.(samples, 2)) > 6
 @test maximum(getindex.(samples, 1)) < 2
 @test maximum(getindex.(samples, 2)) < 8
 
-samples = [DiffEqNoiseProcess.sample_tail(W.rng, W.jpdf, W.tails.tail9) for i=1:100_000]
+samples = [DiffEqNoiseProcess.sample_tail(W.rng, W.jpdf, W.tails.tail9) for i=1:1_000]
 @test minimum(getindex.(samples, 1)) > 2
 @test minimum(getindex.(samples, 2)) > 8
 @test maximum(getindex.(samples, 1)) < 5
 @test maximum(getindex.(samples, 2)) < 10
 
+# compare samples with pdf and check some statistics
+
+samples = [DiffEqNoiseProcess.sample_distribution(W,one(W.dt),nothing,nothing,nothing,W.rng) for i=1:100_000]
+
+dW1 = getindex.(getindex.(samples,1),1)
+dW2 = getindex.(getindex.(samples,1),2)
+r = sqrt.(dW1.^2 + dW2.^2)
+a = abs.(getindex.(getindex.(samples,2),1))
+
+@test mean(dW1) ≈ zero(eltype(r)) atol=1e-2
+@test mean(dW2) ≈ zero(eltype(r)) atol=1e-2
+
+@test var(dW1) ≈ one(eltype(r)) rtol=1e-1
+@test var(dW2) ≈ one(eltype(r)) rtol=1e-1
+
+# BKDE = kde((r, a), boundary=((0,6),(0,6)))
+# @test one(eltype(r)) ≈ sum(BKDE.density)*BKDE.x[2]*BKDE.y[2] rtol=1e-3
+# pl1 = heatmap(BKDE)
+# pl2 = marginalhist(r, a, fc = :plasma,  xlabel="r",  ylabel="a", bins=(64,64))
+# pl3 = plot(0:0.1:6,0:0.1:6,W.jpdf,st =:contourf, xlabel="r", ylabel="a", title="f(r,a)")
+# pl = plot(pl1, pl2, pl3, layout = (1, 3), legend = false, size=(800,250))
+
+
+
+# simulate oop noise problem
+
+dt = 0.1
+calculate_step!(W,dt,nothing,nothing)
+
+for i in 1:10
+  accept_step!(W,dt,nothing,nothing)
+end
+
+prob = NoiseProblem(W,(0.0,1.0));
+sol = solve(prob;dt=0.1)
+
+# simulate iip noise problem
+W = BoxWedgeTail!(0.0,zeros(2))
+
+dt = 0.1
+calculate_step!(W,dt,nothing,nothing)
+
+for i in 1:10
+  accept_step!(W,dt,nothing,nothing)
+end
+
+prob = NoiseProblem(W,(0.0,1.0));
+sol = solve(prob;dt=0.1)
 
 #end

--- a/test/BWT_test.jl
+++ b/test/BWT_test.jl
@@ -1,4 +1,4 @@
-#@testset "BoxWedgeTail tests" begin
+@testset "BoxWedgeTail tests" begin
 
 using DiffEqNoiseProcess, Test, Random
 import Distributions
@@ -246,4 +246,4 @@ end
 prob = NoiseProblem(W,(0.0,1.0));
 sol = solve(prob;dt=0.1)
 
-#end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,4 +22,5 @@ using Test
   include("two_processes.jl")
   include("extraction_test.jl")
   include("restart_test.jl")
+  include("BWT_test.jl")
 end


### PR DESCRIPTION
This PR implements the method for [random generation of stochastic area integrals due to Gaines and Lyons](https://pdfs.semanticscholar.org/f510/6dc3981dc24d91d5164a436ca1c49227b509.pdf?_ga=2.67144087.76420179.1613139250-1545177034.1613139250). The method is based on Marsaglia's "rectangle-wedge-tail" approach for two dimensions. This should allow us to probe the other iterated integral algorithms in StochasticDiffEq, see https://github.com/SciML/StochasticDiffEq.jl/pull/347, https://github.com/SciML/StochasticDiffEq.jl/pull/209.

3 different groupings for the boxes are implemented. 
- `box_grouping = :Columns` (full, i.e., as large as possible, columns on a square spanned by dr and da)
- `box_grouping = :none` (no grouping)
- `box_grouping = :MinEntropy` (default, grouping that achieves a smaller entropy than the column wise grouping and thus allows for slightly faster sampling -- but has a slightly larger amount of groups)

The sampling is based on the `Distributions.jl` package, i.e., to sample from one of the many distributions, a uni-/bi-variate distribution from `Distributions.jl` is constructed and then `rand(..)` is used.

The QuadGK dependency is needed to evaluate the integral in the pdf [see, Eq. (6) of the paper]. The Optim dependency comes from the "Marsaglia's sqeezing method" that is used to sample from the wedges (option: `sqeezing` in the constructor). Instead of standalone rejection sampling with the pdf, an upper (a lower) approximation that allows to quickly reject (accept) a sample is computed, thus speeding up the sample generation. 

The authors state only their final rate in the tail approximations (= average number of points needed to find a sample in a tail region) but not the factor actually used in the rejection sampling [= sup f(x)/g(x)]. I used for the moment this rate which I think is always larger than the sup. With this larger rate, the rejection sampling still works but is less efficient.. This could be tuned by computing the sup, e.g., with `Optim`. Anyway, the tails only make up 0.27% of the distribution.

At the moment it enforces a fixed value of the spatial discretization which they actually use in the paper (`nr=4,na=4,nz=10`) by an `if` condition  because to change the discretization one needs to compute the integrals in the respective region of the joint pdf over dr,da. The requirement (`nr=4,na=4,nz=10`) could thus be dropped easily by adding `Cubature` as a further dependency.

To check that the sampling works, here are some plots (they are as comments in the tests):
```julia
samples = [DiffEqNoiseProcess.sample_box(W, W.boxes) for i=1:1000] # or with wedges/tails
using KernelDensity, StatsPlots, Plots
r = getindex.(samples,1)
a = getindex.(samples,2)
BKDE = kde((r, a), boundary=((0,4),(0,4)))
pl1 = heatmap(BKDE)
pl2 = marginalhist(r, a, fc = :plasma,  xlabel="r",  ylabel="a", bins=(64,64))
pl3 = plot(0:W.Δr:4,0:W.Δa:4,W.jpdf,st =:contourf, xlabel="r", ylabel="a", title="f(r,a)")
pl = plot(pl1, pl2, pl3, layout = (1, 3), legend = false, size=(800,250))
savefig(pl, "boxes.png")
```

Boxes:
![boxes](https://user-images.githubusercontent.com/42201748/107785794-515eaa80-6d4d-11eb-9d4f-b43be16f7b5d.png)
Wedges:
![wedges](https://user-images.githubusercontent.com/42201748/107785808-54599b00-6d4d-11eb-92b8-50eae7ca11ca.png)
Tails:
![tails](https://user-images.githubusercontent.com/42201748/107785815-558ac800-6d4d-11eb-86d2-cee3cd7e8f8b.png)

