### PR TITLE
preconditioned Crank Nicolson

### DIFF
--- a/src/DiffEqNoiseProcess.jl
+++ b/src/DiffEqNoiseProcess.jl
@@ -68,6 +68,6 @@ export accept_step!, reject_step!, calculate_step!, setup_next_step!, save_noise
 
 export CorrelatedWienerProcess, CorrelatedWienerProcess!
 
-export pCN
+export pCN, pCN!
 
 end # module

--- a/src/DiffEqNoiseProcess.jl
+++ b/src/DiffEqNoiseProcess.jl
@@ -36,6 +36,7 @@ include("noise_interfaces/noise_wrapper_interface.jl")
 include("noise_interfaces/box_wedge_tail_interface.jl")
 include("noise_interfaces/common.jl")
 include("correlated_noisefunc.jl")
+include("pCN.jl")
 
 export RSWM
 
@@ -66,5 +67,7 @@ export BoxWedgeTail, BoxWedgeTail!
 export accept_step!, reject_step!, calculate_step!, setup_next_step!, save_noise!
 
 export CorrelatedWienerProcess, CorrelatedWienerProcess!
+
+export pCN
 
 end # module

--- a/src/pCN.jl
+++ b/src/pCN.jl
@@ -1,10 +1,10 @@
 # Preconditioned Crank–Nicolson algorithm tools
 """
-    pCN(noise::AbstractNoiseProcess, ρ; reset=true,reverse=false,indx=nothing)
+    pCN!(noise::AbstractNoiseProcess, ρ; reset=true,reverse=false,indx=nothing)
 
 Create a new, but correlated noise process from `noise` and additional entropy with correlation ρ.
 """
-function pCN(source::AbstractNoiseProcess{T,N,Vector{T2},inplace}, ρ;
+function pCN!(source::AbstractNoiseProcess{T,N,Vector{T2},inplace}, ρ;
               reset=true,reverse=false,indx=nothing) where {T,N,T2,inplace}
 
   # generate new Wiener process similar to the one in source
@@ -20,4 +20,30 @@ function pCN(source::AbstractNoiseProcess{T,N,Vector{T2},inplace}, ρ;
   source.W = ρ * source.W + sqrt(one(ρ)-ρ^2) * Wnew
   source.W = ρ * source.u + sqrt(one(ρ)-ρ^2) * Wnew
   NoiseWrapper(source,reset=reset,reverse=reverse,indx=indx)
+end
+
+
+"""
+    pCN(noise::AbstractNoiseProcess, ρ; reset=true,reverse=false,indx=nothing)
+
+Create a new, but correlated noise process from `noise` and additional entropy with correlation ρ.
+"""
+function pCN(source::AbstractNoiseProcess{T,N,Vector{T2},inplace}, ρ;
+              reset=true,reverse=false,indx=nothing) where {T,N,T2,inplace}
+
+  source′ = deepcopy(source)
+
+  # generate new Wiener process similar to the one in source
+  t = source′.t
+  if typeof(source′.W[1]) <: Number
+    Wnew = cumsum([zero(source′.W[1]);[sqrt.(t[i+1]-ti).*wiener_randn(source′.rng,typeof(source′.W[i]))
+              for (i,ti) in enumerate(t[1:end-1])]])
+  else
+    Wnew = cumsum([[zero(source′.W[1])];[sqrt.(t[i+1]-ti).*wiener_randn(source′.rng,source′.W[i])
+              for (i,ti) in enumerate(t[1:end-1])]])
+  end
+
+  source′.W = ρ * source′.W + sqrt(one(ρ)-ρ^2) * Wnew
+  source′.W = ρ * source′.u + sqrt(one(ρ)-ρ^2) * Wnew
+  NoiseWrapper(source′,reset=reset,reverse=reverse,indx=indx)
 end

--- a/src/pCN.jl
+++ b/src/pCN.jl
@@ -3,6 +3,10 @@
     pCN!(noise::AbstractNoiseProcess, ρ; reset=true,reverse=false,indx=nothing)
 
 Create a new, but correlated noise process from `noise` and additional entropy with correlation ρ.
+This update defines an autoregressive process in the space of Wiener (or noise process) trajectories which can be used as proposal distribution in Metropolis-Hastings algorithms (often called "preconditioned Crank–Nicolson scheme".)
+
+External links
+ * [Preconditioned Crank–Nicolson algorithm on Wikipedia](https://en.wikipedia.org/wiki/Preconditioned_Crank–Nicolson_algorithm)
 """
 function pCN!(source::AbstractNoiseProcess{T,N,Vector{T2},inplace}, ρ;
               reset=true,reverse=false,indx=nothing) where {T,N,T2,inplace}

--- a/src/pCN.jl
+++ b/src/pCN.jl
@@ -1,4 +1,9 @@
 # Preconditioned Crank–Nicolson algorithm tools
+"""
+    pCN(noise::AbstractNoiseProcess, ρ; reset=true,reverse=false,indx=nothing)
+
+Create a new, but correlated noise process from `noise` and additional entropy with correlation ρ.
+"""
 function pCN(source::AbstractNoiseProcess{T,N,Vector{T2},inplace}, ρ;
               reset=true,reverse=false,indx=nothing) where {T,N,T2,inplace}
 

--- a/src/pCN.jl
+++ b/src/pCN.jl
@@ -1,0 +1,18 @@
+# Preconditioned Crank–Nicolson algorithm tools
+function pCN(source::AbstractNoiseProcess{T,N,Vector{T2},inplace}, ρ;
+              reset=true,reverse=false,indx=nothing) where {T,N,T2,inplace}
+
+  # generate new Wiener process similar to the one in source
+  t = source.t
+  if typeof(source.W[1]) <: Number
+    Wnew = cumsum([zero(source.W[1]);[sqrt.(t[i+1]-ti).*wiener_randn(source.rng,typeof(source.W[i]))
+              for (i,ti) in enumerate(t[1:end-1])]])
+  else
+    Wnew = cumsum([[zero(source.W[1])];[sqrt.(t[i+1]-ti).*wiener_randn(source.rng,source.W[i])
+              for (i,ti) in enumerate(t[1:end-1])]])
+  end
+
+  source.W = ρ * source.W + sqrt(one(ρ)-ρ^2) * Wnew
+  source.W = ρ * source.u + sqrt(one(ρ)-ρ^2) * Wnew
+  NoiseWrapper(source,reset=reset,reverse=reverse,indx=indx)
+end

--- a/test/pcn_test.jl
+++ b/test/pcn_test.jl
@@ -1,0 +1,113 @@
+@testset "preconditioned Crank Nicolson tests" begin
+
+using DiffEqNoiseProcess, Test, Random
+using Statistics
+using DiffEqBase
+using DiffEqBase.EnsembleAnalysis
+
+##
+# Tests with
+##
+
+W = WienerProcess(0.0,0.0,0.0)
+
+dt = 0.1
+calculate_step!(W,dt,nothing,nothing)
+
+for i in 1:10
+  accept_step!(W,dt,nothing,nothing)
+end
+
+_W = deepcopy(W)
+
+# test with ρ=1
+W2 = pCN(_W, 1.0)
+WWrapper = NoiseWrapper(_W)
+
+
+# test source
+@test W2.source.W == WWrapper.source.W
+@test W2.source.Z == WWrapper.source.Z
+@test W2.source.W == W.W
+@test W2.source.Z == W.Z
+
+# multi dimensional
+W = WienerProcess(0.0,zeros(4),zeros(4))
+
+dt = 0.1
+calculate_step!(W,dt,nothing,nothing)
+
+for i in 1:10
+  accept_step!(W,dt,nothing,nothing)
+end
+
+_W = deepcopy(W)
+
+W2 = pCN(_W, 1.0)
+WWrapper = NoiseWrapper(_W)
+
+# test source
+@test W2.source.W == WWrapper.source.W
+@test W2.source.Z == WWrapper.source.Z
+@test W2.source.W == _W.W
+@test W2.source.Z == _W.Z
+@test W2.source.W == W.W
+@test W2.source.Z == W.Z
+
+
+# test ρ!=0 and ρ!=1
+W3 = pCN(_W, 0.2)
+
+# test source
+@test W3.source.W != W.W
+@test W3.source.Z == W.Z # no action on auxilary process
+
+# inplace
+W = WienerProcess!(0.0,zeros(4),zeros(4))
+
+dt = 0.1
+calculate_step!(W,dt,nothing,nothing)
+
+for i in 1:10
+  accept_step!(W,dt,nothing,nothing)
+end
+
+_W = deepcopy(W)
+
+# test with ρ=0
+W2 = pCN(_W, 0.0)
+WWrapper = NoiseWrapper(_W)
+
+# test source
+@test W2.source.W != W.W
+@test W2.source.Z == W.Z
+
+# statistics test
+W = WienerProcess(0.0,0.0,0.0)
+prob = NoiseProblem(W,(0.0,1.0))
+sol = solve(prob,dt=0.1)
+
+function prob_func(prob,i,repeat)
+  _sol = deepcopy(sol)
+  Wtmp = pCN(_sol,1.0)
+  remake(prob, noise=Wtmp)
+end
+
+ensemble_prob = EnsembleProblem(prob, prob_func=prob_func)
+@time sim = solve(ensemble_prob,dt=0.1,trajectories=100)
+
+# Spot check the mean and the variance
+qs = 0:0.1:1
+for i in 1:11
+  q = qs[i]
+  @test ≈(timestep_mean(sim,i),sol.W[i],atol=1e-2)
+  @test ≈(timestep_meanvar(sim,i)[2],zero(sol.W[i]),atol=1e-2)
+end
+
+
+# using Plots
+# m_series = [timestep_mean(sim,i)  for i in 1:11]
+# plot(m_series)
+# plot!(sol.W)
+
+end

--- a/test/pcn_test.jl
+++ b/test/pcn_test.jl
@@ -131,8 +131,8 @@ computedW(sim, indx) = (sim.u[indx+1]-sim.u[indx])/sqrt(sim.t[indx+1]-sim.t[indx
 dWnew = []
 dWold = []
 for i in 1:length(sol.t[1:end-1])
-  push!(dWnew,computedW(sol,i,step(qs)))
-  push!(dWold,computedW(sol2,i,step(qs)))
+  push!(dWnew,computedW(sol,i))
+  push!(dWold,computedW(sol2,i))
 end
 @show cor(dWnew,dWold)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,4 +23,5 @@ using Test
   include("extraction_test.jl")
   include("restart_test.jl")
   include("BWT_test.jl")
+  include("pcn_test.jl")
 end


### PR DESCRIPTION
Adds the preconditioned Crank Nicolson proposal (https://en.wikipedia.org/wiki/Preconditioned_Crank%E2%80%93Nicolson_algorithm) to update innovations based on `NoiseWrapper`.

This currently modifies the `source.W` directly -- should this actually be a safetycopy?
Regarding the statistics, there is now only a test if rho = 1, i.e., no update of the process.. Is there a good test on the mean and variance for rho<1, see 

```julia
  @test ≈(timestep_mean(sim,i),sol.W[i],atol=1e-2)
  @test ≈(timestep_meanvar(sim,i)[2],zero(sol.W[i]),atol=1e-2)
```
below.


@mschauer @fmeulen