### PR TITLE
allows to start the NoiseProcess with a different index

### DIFF
--- a/src/noise_interfaces/common.jl
+++ b/src/noise_interfaces/common.jl
@@ -50,15 +50,23 @@ function DiffEqBase.reinit!(W::AbstractNoiseProcess,dt;
   W.curt = t0
   W.dt = dt
   if typeof(W) <: NoiseGrid
+    if t0 == W.t[1]
+      idx = 1
+    else
+      tdir = sign(W.t[2]-W.t[1])
+      @inbounds idx = searchsortedfirst(W.t,t0-tdir*10eps(typeof(t0)),rev=tdir<0)
+      (tdir<0) && (idx-=one(idx))
+    end
+
     if isinplace(W)
-      W.curW .= W.W[1]
+      W.curW .= W.W[idx]
       if W.Z != nothing
-        W.curZ .= W.Z[1]
+        W.curZ .= W.Z[idx]
       end
     else
-      W.curW = W.W[1]
+      W.curW = W.W[idx]
       if W.Z != nothing
-        W.curZ = W.Z[1]
+        W.curZ = W.Z[idx]
       end
     end
     W.step_setup = true

--- a/src/noise_interfaces/noise_grid_interface.jl
+++ b/src/noise_interfaces/noise_grid_interface.jl
@@ -46,7 +46,7 @@ end
 function interpolate!(out1,out2,W::NoiseGrid,t)
   ts,timeseries,timeseries2 = W.t,W.W,W.Z
   sign(W.dt)*t > sign(W.dt)*(ts[end]+10*sign(W.dt)*eps(typeof(t))) && error("Solution interpolation cannot extrapolate past the final timepoint. Build a longer NoiseGrid to cover the integration.")
-  sign(W.dt)*t < sign(W.dt)*(ts[1]+10*sign(W.dt)*eps(typeof(t))) && error("Solution interpolation cannot extrapolate before the first timepoint. Build a longer NoiseGrid to cover the integration.")
+  sign(W.dt)*t < sign(W.dt)*(ts[1]-10*sign(W.dt)*eps(typeof(t))) && error("Solution interpolation cannot extrapolate before the first timepoint. Build a longer NoiseGrid to cover the integration.")
   tdir = sign(ts[end]-ts[1])
 
 


### PR DESCRIPTION
This selects the proper index in the case that `t0 != W.t[1]`.

see also https://github.com/SciML/StochasticDiffEq.jl/pull/409