### PR TITLE
Noise grid dispatch for pCN function

### DIFF
--- a/src/pCN.jl
+++ b/src/pCN.jl
@@ -1,4 +1,18 @@
 # Preconditioned Crank–Nicolson algorithm tools
+
+function generate_innovation(W0::Number,t,rng)
+  dt = diff(t)
+  Wnew = cumsum([zero(W0);[sqrt(dt[i]).*wiener_randn(rng,typeof(W0))
+            for i in 1:length(t)-1]])
+end
+
+function generate_innovation(W0,t,rng)
+  dt = diff(t)
+  Wnew = cumsum([[zero(W0)];[sqrt(dt[i]).*wiener_randn(rng,W0)
+            for i in 1:length(t)-1]])
+end
+
+
 """
     pCN!(noise::AbstractNoiseProcess, ρ; reset=true,reverse=false,indx=nothing)
 
@@ -12,14 +26,7 @@ function pCN!(source::AbstractNoiseProcess{T,N,Vector{T2},inplace}, ρ;
               reset=true,reverse=false,indx=nothing) where {T,N,T2,inplace}
 
   # generate new Wiener process similar to the one in source
-  t = source.t
-  if typeof(source.W[1]) <: Number
-    Wnew = cumsum([zero(source.W[1]);[sqrt.(t[i+1]-ti).*wiener_randn(source.rng,typeof(source.W[i]))
-              for (i,ti) in enumerate(t[1:end-1])]])
-  else
-    Wnew = cumsum([[zero(source.W[1])];[sqrt.(t[i+1]-ti).*wiener_randn(source.rng,source.W[i])
-              for (i,ti) in enumerate(t[1:end-1])]])
-  end
+  Wnew = generate_innovation(source.W[1],source.t,source.rng)
 
   source.W = ρ * source.W + sqrt(one(ρ)-ρ^2) * Wnew
   source.u = ρ * source.u + sqrt(one(ρ)-ρ^2) * Wnew
@@ -38,16 +45,29 @@ function pCN(source::AbstractNoiseProcess{T,N,Vector{T2},inplace}, ρ;
   source′ = deepcopy(source)
 
   # generate new Wiener process similar to the one in source
-  t = source′.t
-  if typeof(source′.W[1]) <: Number
-    Wnew = cumsum([zero(source′.W[1]);[sqrt.(t[i+1]-ti).*wiener_randn(source′.rng,typeof(source′.W[i]))
-              for (i,ti) in enumerate(t[1:end-1])]])
-  else
-    Wnew = cumsum([[zero(source′.W[1])];[sqrt.(t[i+1]-ti).*wiener_randn(source′.rng,source′.W[i])
-              for (i,ti) in enumerate(t[1:end-1])]])
-  end
+  Wnew = generate_innovation(source′.W[1],source′.t,source′.rng)
 
   source′.W = ρ * source′.W + sqrt(one(ρ)-ρ^2) * Wnew
   source′.u = ρ * source′.u + sqrt(one(ρ)-ρ^2) * Wnew
   NoiseWrapper(source′,reset=reset,reverse=reverse,indx=indx)
+end
+
+
+"""
+    pCN(noise::NoiseGrid, ρ; reset=true, rng = Xorshifts.Xoroshiro128Plus(rand(UInt64)))
+
+Create a new, but correlated noise process from `noise` and additional entropy with correlation ρ.
+This update defines an autoregressive process in the space of Wiener (or noise process) trajectories which can be used as proposal distribution in Metropolis-Hastings algorithms (often called "preconditioned Crank–Nicolson scheme".)
+
+External links
+ * [Preconditioned Crank–Nicolson algorithm on Wikipedia](https://en.wikipedia.org/wiki/Preconditioned_Crank–Nicolson_algorithm)
+"""
+function pCN(source::NoiseGrid, ρ; reset=true, rng = Xorshifts.Xoroshiro128Plus(rand(UInt64)))
+
+  # generate new Wiener process similar to the one in source
+  t = source.t
+  Wnew = generate_innovation(source.W[1],source.t,rng)
+
+  W = ρ * source.W + sqrt(one(ρ)-ρ^2) * Wnew
+  NoiseGrid(t,W,source.Z;reset=reset)
 end

--- a/test/pcn_test.jl
+++ b/test/pcn_test.jl
@@ -142,4 +142,31 @@ end
 
 @test ≈(cor(dWnew,dWold),ρ,atol=1e-2)
 
+# Noise Grid tests
+
+trange = 0.0:0.001:1000.0
+
+# scalar
+Ws = cumsum([0.0;[sqrt(trange[i+1]-ti)*randn()
+        for (i,ti) in enumerate(trange[1:end-1])]])
+NG = NoiseGrid(trange,Ws)
+NG2 = pCN(NG,1.0) # ρ = 1.0
+NG3 = pCN(NG,0.5) # ρ = 0.5
+
+@test ≈(cor(diff(NG.W)./sqrt.(diff(NG.t)), diff(NG2.W)./sqrt.(diff(NG2.t))),1,atol=1e-2)
+@test ≈(cor(diff(NG.W)./sqrt.(diff(NG.t)), diff(NG3.W)./sqrt.(diff(NG3.t))),0.5,atol=1e-2)
+
+# array
+dim = 4
+Ws = cumsum([[zeros(dim)];[sqrt(trange[i+1]-ti)*randn(dim)
+        for (i,ti) in enumerate(trange[1:end-1])]])
+NG = NoiseGrid(trange,Ws)
+NG1 = pCN(NG,1.0) # ρ = 1.0
+NG2 = pCN(NG,0.5) # ρ = 0.5
+
+for i=1:dim
+  @test ≈(cor(getindex.(diff(NG.W)./sqrt.(diff(NG.t)),i),getindex.(diff(NG1.W)./sqrt.(diff(NG1.t)),i)),1.0,atol=1e-2)
+  @test ≈(cor(getindex.(diff(NG.W)./sqrt.(diff(NG.t)),i),getindex.(diff(NG2.W)./sqrt.(diff(NG2.t)),i)),0.5,atol=1e-2)
+end
+
 end

--- a/test/reversal_test.jl
+++ b/test/reversal_test.jl
@@ -272,7 +272,7 @@ end
 
   # plot(ts,reverse(ys))
   # plot!(reverse(ts), sol2.u)
-  @test isapprox(ys,sol2.u, atol=1e-5)
+  @test isapprox(ys,sol2.u, atol=3e-5)
   @test !isapprox(sol1.u,reverse(sol2.u), atol=1e-0)
 
   bwrong(u,p,t) =  b(u,p,t) - 1//2*dσ_dx(u,p,t)*σ(u,p,t)


### PR DESCRIPTION
The use of a noise grid for the pCN function turned out to be useful for non-adaptive solvers, e.g., in https://github.com/mschauer/MitosisStochasticDiffEq.jl/pull/62

[ with the NoiseWrapper version, one needs to recall `pCN` after each trajectory, i.e.,
```julia
sol1, solend1 = MSDE.sample(k1, u0, EM(false), save_noise=true)
Z = pCN(sol1.W, 1.0)
sol2, solend2 = MSDE.sample(k2, u0, EM(false), Z)
Z = pCN(sol1.W, 1.0)
sol3, solend3 = MSDE.sample(k3, u0, EM(false), Z)
Z = pCN(sol1.W, 1.0)
```
to have solend1=solend2=solend3.
]

