### PR TITLE
Reversal fixes

### DIFF
--- a/src/noise_interfaces/common.jl
+++ b/src/noise_interfaces/common.jl
@@ -78,7 +78,11 @@ end
 
 function Base.reverse(W::AbstractNoiseProcess)
   if typeof(W) <: NoiseGrid
-    backwardnoise = NoiseGrid(reverse(W.t),reverse(W.W))
+    if W.Z === nothing
+      backwardnoise = NoiseGrid(reverse(W.t),reverse(W.W))
+    else
+      backwardnoise = NoiseGrid(reverse(W.t),reverse(W.W),reverse(W.Z))
+    end
   else
     W.save_everystep = false
     backwardnoise = NoiseWrapper(W, reverse=true)

--- a/src/noise_interfaces/noise_process_interface.jl
+++ b/src/noise_interfaces/noise_process_interface.jl
@@ -521,7 +521,7 @@ end
       if reverse
         W0,Wh = W.W[i],W.W[i-1]
         if W.Z != nothing
-          Z0,Zh = W.Z[i+1],W.Z[i]
+          Z0,Zh = W.Z[i],W.Z[i-1]
         end
         h = W.t[i-1]-W.t[i]
         q = (t-W.t[i])/h

--- a/test/noise_wrapper.jl
+++ b/test/noise_wrapper.jl
@@ -239,19 +239,16 @@ end
 
   @test length(checkWrapper.u) != length(sol.u)
 
-  @test checkWrapper.u[end-1] ≈ sol.u[end-1] rtol=1e-13
-  @test checkWrapper.u[end] ≈ sol.u[end] rtol=1e-13
-  @test checkWrapper.W.W[end] ≈ sol.W.W[end] rtol=1e-16
-  @test checkWrapper(sol.t[indx1:end]).u ≈ sol.u[indx1:end]  rtol=1e-14
-
+  @test checkWrapper.u[end-1] ≈ sol.u[end-1] rtol=1e-10
+  @test checkWrapper.u[end] ≈ sol.u[end] rtol=1e-10
+  @test checkWrapper.W.W[end] ≈ sol.W.W[end] rtol=1e-10
+  @test checkWrapper(sol.t[indx1:end]).u ≈ sol.u[indx1:end]  rtol=1e-10
 
   # pl1 = using Plots; plot(checkWrapper.t[2:end]-checkWrapper.t[1:end-1], label="sol.t")
   # pl2 = plot(checkWrapper.W.t[2:end]-checkWrapper.W.t[1:end-1], label="sol.W.t")
   # pl3 = plot(vcat(checkWrapper.u[2:end]-checkWrapper.u[1:end-1]...), label="sol.u")
   # pl4 = plot(checkWrapper.W.t[2:end], vcat(checkWrapper.W[2:end]-checkWrapper.W[1:end-1]...), label="sol.W")
   # plot!(_sol.t[indx1+1:end], vcat(_sol.W.W[indx1+1:end]-_sol.W.W[indx1:end-1]...), label="sol.W")
-
-
 
   _sol = deepcopy(soloop)
   sol.W.save_everystep = false
@@ -264,8 +261,8 @@ end
 
   @test length(checkWrapper.u) != length(soloop.u)
 
-  @test checkWrapper.u[end-1] ≈ soloop.u[end-1] rtol=1e-13
-  @test checkWrapper.u[end] ≈ soloop.u[end] rtol=1e-13
-  @test checkWrapper.W.W[end] ≈ soloop.W.W[end] rtol=1e-16
-  @test checkWrapper(soloop.t[indx1:end]).u ≈ soloop.u[indx1:end]  rtol=1e-14
+  @test checkWrapper.u[end-1] ≈ soloop.u[end-1] rtol=1e-10
+  @test checkWrapper.u[end] ≈ soloop.u[end] rtol=1e-10
+  @test checkWrapper.W.W[end] ≈ soloop.W.W[end] rtol=1e-10
+  @test checkWrapper(soloop.t[indx1:end]).u ≈ soloop.u[indx1:end]  rtol=1e-10
 end

--- a/test/noise_wrapper.jl
+++ b/test/noise_wrapper.jl
@@ -217,12 +217,6 @@ end
 
   @test length(sol.u) != 1e4+1
 
-  # pl1 = using Plots; plot(sol.t[2:end]-sol.t[1:end-1], label="sol.t")
-  # pl2 = plot(sol.W.t[2:end]-sol.W.t[1:end-1], label="sol.W.t")
-  # pl3 = plot(vcat(sol.u[2:end]-sol.u[1:end-1]...), label="sol.u")
-  # pl4 = plot(log.(abs.(vcat(sol.W[2:end]-sol.W[1:end-1]...))), label="sol.W")
-
-
   indx1 = Int(length(sol.t) - 100)
   interval = (sol.t[indx1], sol.t[end])
 
@@ -234,21 +228,15 @@ end
 
   forwardnoise = DiffEqNoiseProcess.NoiseWrapper(_sol.W, indx=indx1)
 
-  checkWrapper = solve(remake(_sol.prob, tspan=interval, u0=_sol(interval[1]), noise=forwardnoise), _sol.alg, save_noise=false; dt=abs(_sol.W.t[end-1]-_sol.W.t[end-2]-10eps(1.0)),tstops = sol.t[indx1:end])
-
+  checkWrapper = solve(remake(_sol.prob, tspan=interval, u0=_sol(interval[1]), noise=forwardnoise), _sol.alg, save_noise=false; dt=abs(_sol.W.t[end-1]-_sol.W.t[end-2]),tstops = sol.t[indx1:end])
 
   @test length(checkWrapper.u) != length(sol.u)
 
+  @test checkWrapper.u[1] ≈ sol.u[indx1] rtol=1e-10
   @test checkWrapper.u[end-1] ≈ sol.u[end-1] rtol=1e-10
   @test checkWrapper.u[end] ≈ sol.u[end] rtol=1e-10
   @test checkWrapper.W.W[end] ≈ sol.W.W[end] rtol=1e-10
   @test checkWrapper(sol.t[indx1:end]).u ≈ sol.u[indx1:end]  rtol=1e-10
-
-  # pl1 = using Plots; plot(checkWrapper.t[2:end]-checkWrapper.t[1:end-1], label="sol.t")
-  # pl2 = plot(checkWrapper.W.t[2:end]-checkWrapper.W.t[1:end-1], label="sol.W.t")
-  # pl3 = plot(vcat(checkWrapper.u[2:end]-checkWrapper.u[1:end-1]...), label="sol.u")
-  # pl4 = plot(checkWrapper.W.t[2:end], vcat(checkWrapper.W[2:end]-checkWrapper.W[1:end-1]...), label="sol.W")
-  # plot!(_sol.t[indx1+1:end], vcat(_sol.W.W[indx1+1:end]-_sol.W.W[indx1:end-1]...), label="sol.W")
 
   _sol = deepcopy(soloop)
   sol.W.save_everystep = false
@@ -256,11 +244,12 @@ end
 
   forwardnoise = DiffEqNoiseProcess.NoiseWrapper(_sol.W, indx=indx1)
 
-  checkWrapper = solve(remake(_sol.prob, tspan=interval, u0=_sol(interval[1]), noise=forwardnoise), _sol.alg, save_noise=false; dt=abs(_sol.W.t[end-1]-_sol.W.t[end-2]-10eps(1.0)),tstops = sol.t[indx1:end])
+  checkWrapper = solve(remake(_sol.prob, tspan=interval, u0=_sol(interval[1]), noise=forwardnoise), _sol.alg, save_noise=false; dt=abs(_sol.W.t[end-1]-_sol.W.t[end-2]),tstops = sol.t[indx1:end])
 
 
   @test length(checkWrapper.u) != length(soloop.u)
 
+  @test checkWrapper.u[1] ≈ sol.u[indx1] rtol=1e-10
   @test checkWrapper.u[end-1] ≈ soloop.u[end-1] rtol=1e-10
   @test checkWrapper.u[end] ≈ soloop.u[end] rtol=1e-10
   @test checkWrapper.W.W[end] ≈ soloop.W.W[end] rtol=1e-10


### PR DESCRIPTION
The `BoundsError` reported in: https://discourse.julialang.org/t/diffeqflux-sosra2-algorithm-backsolveadjoint-gives-an-error/61237
was thrown from the false assignment of the auxilary `Z0` and  `Zh` noise values in `src/noise_interfaces/noise_process_interface.jl` (see line above for the associated `W` values).

I added some more tests for the reversion of the noise trajectory. 

The modified tolerances in noise_wrapper.jl aim to fix the failing downstream tests in: https://github.com/SciML/StochasticDiffEq.jl/pull/417.