### PR TITLE
allow solvers to use Noise Grid with SVectors

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -268,7 +268,7 @@ function NoiseGrid(t,W,Z=nothing;reset=true)
     curZ = copy(Z[1])
     dZ = copy(Z[1])
   end
-  (typeof(val) <: AbstractArray && !(typeof(val) <: SArray))? iip = true : iip = false
+  (typeof(val) <: AbstractArray && !(typeof(val) <: SArray)) ? iip = true : iip = false
   NoiseGrid{typeof(val),ndims(val),typeof(dt),typeof(dW),typeof(dZ),typeof(Z),iip}(
             t,W,W,Z,curt,curW,curZ,dt,dW,dZ,true,reset)
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -268,7 +268,7 @@ function NoiseGrid(t,W,Z=nothing;reset=true)
     curZ = copy(Z[1])
     dZ = copy(Z[1])
   end
-  typeof(val) <: AbstractArray ? iip = true : iip = false
+  (typeof(val) <: AbstractArray && !(typeof(val) <: SArray))? iip = true : iip = false
   NoiseGrid{typeof(val),ndims(val),typeof(dt),typeof(dW),typeof(dZ),typeof(Z),iip}(
             t,W,W,Z,curt,curW,curZ,dt,dW,dZ,true,reset)
 end


### PR DESCRIPTION
For the MitosisStochasticDiffEq JuliaCon example https://github.com/mschauer/MitosisStochasticDiffEq.jl/pull/62, we currently have a few workarounds which basically just avoid inplace mutations with `NoiseGrid` when using SVectors. Wouldn't it make sense to make this a default? 