### PR TITLE
Fix Ito reverse noise processes

### DIFF
--- a/src/noise_interfaces/common.jl
+++ b/src/noise_interfaces/common.jl
@@ -55,7 +55,7 @@ function DiffEqBase.reinit!(W::AbstractNoiseProcess, dt;
             tdir = sign(W.t[2] - W.t[1])
             @inbounds idx = searchsortedfirst(W.t, t0 - tdir * 10eps(typeof(t0)),
                                               rev = tdir < 0)
-            (tdir < 0) && (idx -= one(idx))
+            # (tdir < 0) && (idx -= one(idx))
         end
 
         if isinplace(W)

--- a/src/types.jl
+++ b/src/types.jl
@@ -959,8 +959,8 @@ mutable struct BoxWedgeTail{T,N,Tt,TA,T2,T3,ZType,F,F2,inplace,RNGType,tolType,
   spacingType,jpdfType,boxType,wedgeType,tailType,distBWTType,distΠType} <: AbstractNoiseProcess{T,N,Vector{T2},inplace}
 ```
 
-The method for random generation of stochastic area integrals due to Gaines and Lyons. The method is 
-based on Marsaglia's "rectangle-wedge-tail" approach for two dimensions. 
+The method for random generation of stochastic area integrals due to Gaines and Lyons. The method is
+based on Marsaglia's "rectangle-wedge-tail" approach for two dimensions.
 
 3 different groupings for the boxes are implemented.
 
@@ -968,7 +968,7 @@ based on Marsaglia's "rectangle-wedge-tail" approach for two dimensions.
 - box_grouping = :none (no grouping)
 - box_grouping = :MinEntropy (default, grouping that achieves a smaller entropy than the column wise grouping and thus allows for slightly faster sampling -- but has a slightly larger amount of groups)
 
-The sampling is based on the Distributions.jl package, i.e., to sample from one of the many distributions, 
+The sampling is based on the Distributions.jl package, i.e., to sample from one of the many distributions,
 a uni-/bi-variate distribution from Distributions.jl is constructed and then rand(..) is used.
 
 ## Constructor

--- a/test/reversal_test.jl
+++ b/test/reversal_test.jl
@@ -206,9 +206,9 @@ end
 
     seed = 10
     Random.seed!(seed)
-    W = [0.0; cumsum(sqrt(dt) * randn(n))]
-    #using Plots; plot(W)
-
+    W = [0.0; cumsum(sqrt(dt) * randn(n + 1))]
+    ts = collect(0.0:dt:(T + dt))
+    ts2 = ts[1:(end - 1)]
     p = nothing
 
     """
@@ -218,20 +218,15 @@ end
     x = x0 # starting point
     xs = [x]
     t = 0.0
-    ts = [0.0]
     for i in 1:n
         t, x
-        #@show x, dt, (W[i+1] - W[i]), x+b(x,p,t)*dt, σ(x,p,t)*(W[i+1] - W[i])
         x += b(x, p, t) * dt + σ(x, p, t) * (W[i + 1] - W[i]) # this is an ito integral
         t += dt
         push!(xs, x)
-        push!(ts, t)
     end
 
     z = xs[end]
 
-    #plt = plot(ts,xs)
-    #plt = plot(xs)
     # Now reverse... t
 
     dσ_dx(u, p, t) = 1 / (1 + u^2) # d(arctan(x))/dx
@@ -239,36 +234,25 @@ end
     @show "starting point" z
     ys = [z]
     t = T
-    cs = [0.0]
     for i in n:-1:1
         t, z
         cor = 1 / 2 * dσ_dx(z, p, t) * σ(z, p, t)
         z -= (b(z, p, t) - 0 * 2 * cor) * dt + σ(z, p, t) * (W[i + 1] - W[i]) # reverse ito integral
         t -= dt
         push!(ys, z)
-        push!(cs, cor)
     end
 
-    #plot!(ts,reverse(ys))
-    # difference between forward and backward
-    #plot(reverse(ys)-xs)
-    # correction terms
-    #plot(cs)
-    #using DiffEqNoiseProcess, StochasticDiffEq
-
     W1 = NoiseGrid(ts, W)
-    prob1 = SDEProblem(b, σ, x0, (0.0, 2.0 - 1e-11), noise = W1)
+    prob1 = SDEProblem(b, σ, x0, (0.0, 2.0), noise = W1)
     sol1 = solve(prob1, EM(false), dt = dt, adaptive = false)
 
-    @test isapprox(xs, sol1.u, atol = 1e-8)
+    @test isapprox(xs, sol1(ts2).u, rtol = 1e-8)
 
     W1rev = NoiseGrid(reverse(ts), reverse(W))
     prob1 = SDEProblem(b, σ, sol1.u[end], (sol1.t[end], sol1.t[1]), noise = W1rev)
     sol2 = solve(prob1, EM(false), dt = dt, adaptive = false)
 
-    # plot(ts,reverse(ys))
-    # plot!(reverse(ts), sol2.u)
-    @test isapprox(ys, sol2.u, atol = 1e-3)
+    @test isapprox(ys, sol2(reverse(ts2)).u, atol = 1e-3)
     @test !isapprox(sol1.u, reverse(sol2.u), atol = 1e-0)
 
     bwrong(u, p, t) = b(u, p, t) - 1 // 2 * dσ_dx(u, p, t) * σ(u, p, t)
@@ -276,7 +260,7 @@ end
     prob1 = SDEProblem(bwrong, σ, sol1.u[end], (sol1.t[end], sol1.t[1]), noise = W1rev)
     sol2 = solve(prob1, EM(false), dt = dt, adaptive = false)
 
-    @test !isapprox(ys, sol2.u, atol = 1e-0)
+    @test !isapprox(ys, sol2(reverse(ts2)).u, atol = 1e-0)
     @test !isapprox(sol1.u, reverse(sol2.u), atol = 1e-0)
 
     bcorrected(u, p, t) = b(u, p, t) - 2 * 1 // 2 * dσ_dx(u, p, t) * σ(u, p, t)
@@ -285,8 +269,8 @@ end
     sol2 = solve(prob1, EM(false), dt = dt, adaptive = false)
 
     #plot(ts, sol1.u - reverse(sol2.u))
-    @test !isapprox(ys, sol2.u, atol = 1e-6)
-    @test isapprox(sol1.u, reverse(sol2.u), atol = 1e-0)
+    @test !isapprox(ys, sol2(reverse(ts2)).u, atol=1e-6)
+    @test isapprox(sol1(ts2).u, sol2(ts2).u, atol = 1e-0)
 end
 
 """
@@ -313,7 +297,8 @@ Some more Ito reversals
     fcorrected!(du, u, p, t) = du .= (α - β^2) * u
 
     _sol = deepcopy(sol) # to make sure the plot is correct
-    W1 = NoiseGrid(reverse(_sol.t), reverse(_sol.W.W)
+    W1 = NoiseGrid(reverse(_sol.t),
+                   reverse(_sol.W.W)
                    # ,reverse(_sol.W.Z)
                    )
     prob1 = SDEProblem(fcorrected!, g!, sol[end], reverse(tspan), noise = W1)
@@ -339,7 +324,8 @@ Some more Ito reversals
     fcorrected(u, p, t) = (α - β^2) * u
 
     _sol = deepcopy(sol) # to make sure the plot is correct
-    W1 = NoiseGrid(reverse(_sol.t), reverse(_sol.W.W)
+    W1 = NoiseGrid(reverse(_sol.t),
+                   reverse(_sol.W.W)
                    # ,reverse(_sol.W.Z)
                    )
     prob1 = SDEProblem(fcorrected, g, sol[end], reverse(tspan), noise = W1)

--- a/test/reversal_test.jl
+++ b/test/reversal_test.jl
@@ -269,7 +269,7 @@ end
     sol2 = solve(prob1, EM(false), dt = dt, adaptive = false)
 
     #plot(ts, sol1.u - reverse(sol2.u))
-    @test !isapprox(ys, sol2(reverse(ts2)).u, atol=1e-6)
+    @test !isapprox(ys, sol2(reverse(ts2)).u, atol = 1e-6)
     @test isapprox(sol1(ts2).u, sol2(ts2).u, atol = 1e-0)
 end
 


### PR DESCRIPTION
Related to: https://github.com/SciML/StochasticDiffEq.jl/pull/489

Seems unnecessary/wrong to subtract one from `idx`. 