### PR TITLE
Handle warnings in tests

### DIFF
--- a/src/noise_interfaces/box_wedge_tail_interface.jl
+++ b/src/noise_interfaces/box_wedge_tail_interface.jl
@@ -381,9 +381,10 @@ end
 # sampling from boxes
 function sample_box(W::BoxWedgeTail, Boxes::AbstractBoxGeneration)
     indx = rand(W.rng, Boxes.dist)
-    # boxes store r, a, Δr, Δa 
+    # boxes store r, a, Δr, Δa
     ri, ai, Δr, Δa = Boxes.boxes[indx]
-    DU = Distributions.Product(Distributions.Uniform.([ri, ai], [ri + Δr, ai + Δa]))
+    DU = Distributions.product_distribution(Distributions.Uniform.([ri, ai],
+                                                                   [ri + Δr, ai + Δa]))
 
     r, a = rand(W.rng, DU)
     return r, a
@@ -458,8 +459,12 @@ function sample_wedge(W::BoxWedgeTail, wedges::Wedges)
     indx = rand(W.rng, wedges.dist)
     # wedges store f̃ij, hij, ϵijmin, ϵijmax, r, a, Δr
     f̃ij, hij, ϵijmin, ϵijmax, ri, ai = wedges.boxes[indx]
-    DU = Distributions.Product(Distributions.Uniform.([ri, ai, hij],
-                                                      [ri + W.Δr, ai + W.Δa, f̃ij]))
+    DU = Distributions.product_distribution(Distributions.Uniform.([ri, ai, hij],
+                                                                   [
+                                                                       ri + W.Δr,
+                                                                       ai + W.Δa,
+                                                                       f̃ij,
+                                                                   ]))
     if W.sqeezing
         fij, fij2, fij3, fij4 = wedges.fvalues[indx]
         while true
@@ -550,7 +555,7 @@ struct Tail3{pType, distType, pdfType, cType} <: AbstractTail
                                                                           2 / pi)), aM,
                                         8 * one(aM))
 
-        dist = Distributions.Product([dist1, dist2])
+        dist = Distributions.product_distribution([dist1, dist2])
 
         c = convert(typeof(rM), 2.6)
 
@@ -572,7 +577,7 @@ struct Tail4{pType, distType, pdfType, cType} <: AbstractTail
                                                                           1 / pi)), aM,
                                         6 * one(aM))
 
-        dist = Distributions.Product([dist1, dist2])
+        dist = Distributions.product_distribution([dist1, dist2])
 
         c = convert(typeof(rM), 2.6)
 
@@ -594,7 +599,7 @@ struct Tail5{pType, distType, pdfType, cType} <: AbstractTail
                                                                           1 / 2.8)), aM,
                                         6 * one(aM))
 
-        dist = Distributions.Product([dist1, dist2])
+        dist = Distributions.product_distribution([dist1, dist2])
 
         c = convert(typeof(rM), 2.8)
 
@@ -616,7 +621,7 @@ struct Tail6{pType, distType, pdfType, cType} <: AbstractTail
                                                                           1 / 2.6)), aM,
                                         6 * one(aM))
 
-        dist = Distributions.Product([dist1, dist2])
+        dist = Distributions.product_distribution([dist1, dist2])
 
         c = convert(typeof(rM), 3.0)
 
@@ -638,7 +643,7 @@ struct Tail7{pType, distType, pdfType, cType} <: AbstractTail
                                                                           1 / 2.4)), aM,
                                         6 * one(aM))
 
-        dist = Distributions.Product([dist1, dist2])
+        dist = Distributions.product_distribution([dist1, dist2])
 
         c = convert(typeof(rM), 3.2)
 
@@ -660,7 +665,7 @@ struct Tail8{pType, distType, pdfType, cType} <: AbstractTail
                                                                           1 / 2.4)),
                                         6 * one(aM), 8 * one(aM))
 
-        dist = Distributions.Product([dist1, dist2])
+        dist = Distributions.product_distribution([dist1, dist2])
 
         c = convert(typeof(rM), 4.2)
 
@@ -682,7 +687,7 @@ struct Tail9{pType, distType, pdfType, cType} <: AbstractTail
                                                                           2 / pi)),
                                         8 * one(aM), 10 * one(aM))
 
-        dist = Distributions.Product([dist1, dist2])
+        dist = Distributions.product_distribution([dist1, dist2])
 
         c = convert(typeof(rM), 2.4)
 

--- a/test/sde_adaptivedistribution_tests.jl
+++ b/test/sde_adaptivedistribution_tests.jl
@@ -1,6 +1,9 @@
 @testset "SDE Adaptive Distribution Tests" begin
     using StochasticDiffEq, StatsBase, Distributions, HypothesisTests
-    using Random, DiffEqProblemLibrary
+    using Random
+    using DiffEqProblemLibrary.SDEProblemLibrary
+    # load problems
+    SDEProblemLibrary.importsdeproblems()
 
     prob = prob_sde_linear
     Random.seed!(200)
@@ -12,8 +15,9 @@
     for j in 1:M
         Wends = Vector{Float64}(undef, N)
         for i in 1:N
-            sol = solve(prob, SRI(), dt = 1 / 2^(4), abstol = 1e-2, reltol = 0,
-                        adaptivealg = :RSwM1)
+            W = WienerProcess(0.0, 0.0, 0.0, rswm = RSWM(adaptivealg = :RSwM1))
+            _prob = remake(prob, noise = W)
+            sol = solve(_prob, SRI(), dt = 1 / 2^(4), abstol = 1e-2, reltol = 0)
             Wends[i] = sol.W.W[end]
         end
         kssol = ApproximateOneSampleKSTest(Wends / sqrt(T), Normal())
@@ -25,8 +29,9 @@
     for j in 1:M
         Wends = Vector{Float64}(undef, N)
         for i in 1:N
-            sol = solve(prob, SRI(), dt = 1 / 2^(4), abstol = 1e-2, reltol = 0,
-                        adaptivealg = :RSwM2)
+            W = WienerProcess(0.0, 0.0, 0.0, rswm = RSWM(adaptivealg = :RSwM2))
+            _prob = remake(prob, noise = W)
+            sol = solve(_prob, SRI(), dt = 1 / 2^(4), abstol = 1e-2, reltol = 0)
             Wends[i] = sol.W.W[end]
         end
         kssol = ApproximateOneSampleKSTest(Wends / sqrt(T), Normal())
@@ -38,8 +43,9 @@
     for j in 1:M
         Wends = Vector{Float64}(undef, N)
         for i in 1:N
-            sol = solve(prob, SRI(), dt = 1 / 2^(4), abstol = 1e-2, reltol = 0,
-                        adaptivealg = :RSwM3)
+            W = WienerProcess(0.0, 0.0, 0.0, rswm = RSWM(adaptivealg = :RSwM3))
+            _prob = remake(prob, noise = W)
+            sol = solve(_prob, SRI(), dt = 1 / 2^(4), abstol = 1e-2, reltol = 0)
             Wends[i] = sol.W.W[end]
         end
         kssol = ApproximateOneSampleKSTest(Wends / sqrt(T), Normal())


### PR DESCRIPTION
Update for 
```
Warning: `Product(v)` is deprecated, please use `product_distribution(v)`
```
in Box-Wedge-Tail algorithm and SDE adaptive distribution tests (see https://github.com/SciML/DiffEqNoiseProcess.jl/issues/110)