### PR TITLE
add `reinit!` specialized to NoiseWrapper

### DIFF
--- a/src/noise_interfaces/common.jl
+++ b/src/noise_interfaces/common.jl
@@ -133,6 +133,32 @@ function DiffEqBase.reinit!(W::NoiseTransport, dt;
     return nothing
 end
 
+function DiffEqBase.reinit!(W::NoiseWrapper, dt;
+                            t0 = W.t[1],
+                            erase_sol = true,
+                            setup_next = false)
+    W.curt = t0
+    W.dt = dt
+
+    if isinplace(W)
+        W.curW .= W.W[1]
+        W.dW .= W.curW
+        if W.Z !== nothing
+            W.curZ .= W.Z[1]
+            W.dZ .= W.curZ
+        end
+    else
+        W.curW = W.W[1]
+        W.dW = W.curW
+        if W.Z !== nothing
+            W.curZ = W.Z[1]
+            W.dZ = W.curZ
+        end
+    end
+
+    return nothing
+end
+
 function Base.reverse(W::AbstractNoiseProcess)
     if typeof(W) <: NoiseGrid
         if W.Z === nothing

--- a/test/sde_noise_wrapper.jl
+++ b/test/sde_noise_wrapper.jl
@@ -1,4 +1,4 @@
-@testset "NoiseWrapper" begin
+@testset "SDE NoiseWrapper" begin
     using StochasticDiffEq, DiffEqBase, DiffEqNoiseProcess, Test
 
     f1 = (u, p, t) -> 1.01u
@@ -12,7 +12,13 @@
     prob1 = SDEProblem(f1, g1, 1.0, (0.0, 1.0), noise = W2)
 
     sol2 = solve(prob1, EM(), dt = dt)
+    @test sol1.u ≈ sol2.u
 
+    sol2 = solve(prob1, EM(), dt = dt)
+    @test sol1.u ≈ sol2.u
+
+    prob1 = SDEProblem(f1, g1, 1.0, (0.0, 1.0), noise = W2)
+    sol2 = solve(prob1, EM(), dt = dt)
     @test sol1.u ≈ sol2.u
 
     W3 = NoiseWrapper(sol1.W)


### PR DESCRIPTION
This should fix #121 , which was reported on Slack.

Currently, `NoiseWrapper` has no specialized `reinit!` method and falls back to the general one for `AbstractNoiseProcess`, which only sets `W.curW` for a `NoiseGrid`, otherwise `W.curW` is left unchanged. So, when solving it twice, `W.curW` starts the second run with a value equal to the last value of the previous run.

This PR adds a specialized `reinit!` for `NoiseWrapper` that takes care of that.

I could have checked for a `NoiseWrapper` inside the reinit of `AbstractNoiseProcess`, but I though a separate `reinit!` would be cleaner.