### PR TITLE
remove call to deprecated method

### DIFF
--- a/src/noise_interfaces/box_wedge_tail_interface.jl
+++ b/src/noise_interfaces/box_wedge_tail_interface.jl
@@ -506,7 +506,7 @@ struct Tail1{pType, distType, pdfType, cType} <: AbstractTail
                                         12 * one(rM))
         dist2 = Distributions.Uniform(zero(aM), aM)
 
-        dist = Distributions.Product([dist1, dist2])
+        dist = Distributions.product_distribution([dist1, dist2])
 
         c = convert(typeof(rM), 2.3)
 


### PR DESCRIPTION
This just replaces a lingering deprecated call to a method from `Distributions.jl`.