### PR TITLE
Fix reinit

### DIFF
--- a/src/bridges.jl
+++ b/src/bridges.jl
@@ -20,6 +20,7 @@ function BrownianBridge(t0, tend, W0, Wend, Z0 = nothing, Zend = nothing; kwargs
         Zh = nothing
     end
     push!(W.S₁, (h, Wh, Zh))
+    push!(W.reinitS₁, (h, Wh, Zh))
     W
 end
 
@@ -45,6 +46,7 @@ function BrownianBridge!(t0, tend, W0, Wh, Z0 = nothing, Zh = nothing; kwargs...
         Zh = nothing
     end
     push!(W.S₁, (h, Wh, Zh))
+    push!(W.reinitS₁, (h, Wh, Zh))
     W
 end
 
@@ -59,6 +61,7 @@ function GeometricBrownianBridge(μ, σ, t0, tend, W0, Wend, Z0 = nothing, Zend 
         Zh = nothing
     end
     push!(W.S₁, (h, Wh, Zh))
+    push!(W.reinitS₁, (h, Wh, Zh))
     W
 end
 
@@ -73,6 +76,7 @@ function GeometricBrownianBridge!(μ, σ, t0, tend, W0, Wh, Z0 = nothing, Zh = n
         Zh = nothing
     end
     push!(W.S₁, (h, Wh, Zh))
+    push!(W.reinitS₁, (h, Wh, Zh))
     W
 end
 
@@ -81,6 +85,7 @@ function CompoundPoissonBridge(rate, t0, tend, W0, Wend; kwargs...)
     h = tend - t0
     Wh = Wend - W0
     push!(W.S₁, (h, Wh, nothing))
+    push!(W.reinitS₁, (h, Wh, nothing))
     W
 end
 
@@ -89,5 +94,6 @@ function CompoundPoissonBridge!(rate, t0, tend, W0, Wh; kwargs...)
     h = tend - t0
     Wh .-= W0
     push!(W.S₁, (h, Wh, nothing))
+    push!(W.reinitS₁, (h, Wh, nothing))
     W
 end

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -12,12 +12,10 @@ function DiffEqBase.__solve(prob::AbstractNoiseProblem,
             Random.seed!(W.rng, rand(UInt64))
         end
     end
-    if typeof(W) <: NoiseTransport && W.reset
-        reinit!(W, prob.tspan[1], t0 = prob.tspan[1])
-    else
-        W.curt = prob.tspan[1]
-        W.dt = dt
+    if W.reset
+        reinit!(W, dt, t0 = prob.tspan[1])
     end
+
     setup_next_step!(W, nothing, nothing)
     tType = typeof(W.curt)
     while W.curt < prob.tspan[2]

--- a/src/types.jl
+++ b/src/types.jl
@@ -184,8 +184,9 @@ mutable struct NoiseProcess{T, N, Tt, T2, T3, ZType, F, F2, inplace, S1, S2, RSW
                                                          })
         S₂ = ResettableStacks.ResettableStack{iip}(Tuple{typeof(t0), typeof(W0), typeof(Z0)
                                                          })
-        reinitS₁ = ResettableStacks.ResettableStack{iip}(Tuple{typeof(t0), typeof(W0), typeof(Z0)
-        })
+        reinitS₁ = ResettableStacks.ResettableStack{iip}(Tuple{typeof(t0), typeof(W0),
+                                                               typeof(Z0)
+                                                               })
         if Z0 == nothing
             Z = nothing
             curZ = nothing

--- a/src/types.jl
+++ b/src/types.jl
@@ -163,6 +163,7 @@ mutable struct NoiseProcess{T, N, Tt, T2, T3, ZType, F, F2, inplace, S1, S2, RSW
     dZtmp::T3
     S₁::S1
     S₂::S2
+    reinitS₁::S1
     rswm::RSWM
     maxstacksize::Int
     maxstacksize2::Int
@@ -183,6 +184,8 @@ mutable struct NoiseProcess{T, N, Tt, T2, T3, ZType, F, F2, inplace, S1, S2, RSW
                                                          })
         S₂ = ResettableStacks.ResettableStack{iip}(Tuple{typeof(t0), typeof(W0), typeof(Z0)
                                                          })
+        reinitS₁ = ResettableStacks.ResettableStack{iip}(Tuple{typeof(t0), typeof(W0), typeof(Z0)
+        })
         if Z0 == nothing
             Z = nothing
             curZ = nothing
@@ -213,6 +216,7 @@ mutable struct NoiseProcess{T, N, Tt, T2, T3, ZType, F, F2, inplace, S1, S2, RSW
                                                                                    copy(W0),
                                                                                    dZtmp,
                                                                                    S₁, S₂,
+                                                                                   reinitS₁,
                                                                                    rswm, 0,
                                                                                    0,
                                                                                    save_everystep,

--- a/test/reinit_test.jl
+++ b/test/reinit_test.jl
@@ -1,0 +1,129 @@
+@testset "Reinit" begin
+    using StochasticDiffEq, DiffEqNoiseProcess, Statistics
+
+    f = (u, p, t) -> 1.0
+    g = (u, p, t) -> 0.2
+    tspan = (0.5, 1.0)
+
+    @testset "WienerProcess" begin
+        W = WienerProcess(0.0, 0.0)
+        t = 1.0
+        expected_mean = 0.0
+        expected_variance = t^2
+
+        meanW = mean(W.curW for i in 1:10_000 if reinit!(W, 0.0, t0 = t) === nothing)
+        varW = var(W.curW for i in 1:10_000 if reinit!(W, 0.0, t0 = t) === nothing)
+        @test meanW ≈ expected_mean atol = 0.1
+        @test varW ≈ expected_variance rtol = 0.1
+
+        prob = NoiseProblem(W, tspan)
+        ensemble_prob = EnsembleProblem(prob, output_func = (sol, i) -> (sol[end], false))
+        sol = solve(ensemble_prob, dt = 1 / 10, trajectories = 40_000)
+        @test mean(sol)≈expected_mean atol=0.1
+        @test var(sol)≈expected_variance atol=0.1
+
+        prob = SDEProblem(f, g, 1.0, tspan, noise = W, save_noise = true)
+
+        ensemble_probW = EnsembleProblem(prob,
+                                         output_func = (sol, i) -> (sol.W.W[end], false))
+
+        solW_at_1 = solve(ensemble_probW, EM(), dt = 1 / 10, trajectories = 40_000)
+
+        @test mean(solW_at_1)≈expected_mean atol=0.1
+        @test var(solW_at_1)≈expected_variance atol=0.1
+    end
+
+    @testset "GBM" begin
+        μ = 0.5
+        σ = 0.1
+        W0 = 1.0
+        W = GeometricBrownianMotionProcess(μ, σ, 0.0, W0, nothing)
+
+        t = 1.0
+        expected_mean = W0 * exp(μ * t)
+        expected_variance = W0^2 * exp(2μ * t) * (exp(σ^2 * t) - 1)
+
+        meanW = mean(W.curW for i in 1:10_000 if reinit!(W, 0.0, t0 = t) === nothing)
+        varW = var(W.curW for i in 1:10_000 if reinit!(W, 0.0, t0 = t) === nothing)
+        @test meanW ≈ expected_mean atol = 0.1
+        @test varW ≈ expected_variance rtol = 0.1
+
+        prob = NoiseProblem(W, tspan)
+        ensemble_prob = EnsembleProblem(prob, output_func = (sol, i) -> (sol[end], false))
+        sol = solve(ensemble_prob, dt = 1 / 10, trajectories = 40_000)
+        @test mean(sol)≈expected_mean rtol=0.1
+        @test var(sol)≈expected_variance atol=0.1
+
+        prob = SDEProblem(f, g, 1.0, tspan, noise = W, save_noise = true)
+
+        ensemble_probW = EnsembleProblem(prob,
+                                         output_func = (sol, i) -> (sol.W.W[end], false))
+
+        solW_at_1 = solve(ensemble_probW, EM(), dt = 1 / 10, trajectories = 40_000)
+
+        @test mean(solW_at_1)≈expected_mean rtol=0.1
+        @test var(solW_at_1)≈expected_variance atol=0.1
+    end
+
+    @testset "OrnsteinUhlenbeck" begin
+        Θ = 1.0
+        μ = 1.2
+        σ = 0.3
+        W0 = 1.0
+        W = OrnsteinUhlenbeckProcess(Θ, μ, σ, 0.0, W0, nothing)
+
+        t = 1.0
+        expected_mean = μ + (W0 - μ) * exp(-Θ * t)
+        expected_variance = (1 - exp(-2Θ * t)) * σ^2 / (2Θ)
+
+        meanW = mean(W.curW for i in 1:10_000 if reinit!(W, 0.0, t0 = t) === nothing)
+        varW = var(W.curW for i in 1:10_000 if reinit!(W, 0.0, t0 = t) === nothing)
+        @test meanW ≈ expected_mean atol = 0.1
+        @test varW ≈ expected_variance rtol = 0.1
+
+        prob = NoiseProblem(W, tspan)
+        ensemble_prob = EnsembleProblem(prob, output_func = (sol, i) -> (sol[end], false))
+        sol = solve(ensemble_prob, dt = 1 / 10, trajectories = 40_000)
+        @test mean(sol)≈expected_mean rtol=0.1
+        @test var(sol)≈expected_variance atol=0.1
+
+        prob = SDEProblem(f, g, 1.0, tspan, noise = W, save_noise = true)
+
+        ensemble_probW = EnsembleProblem(prob,
+                                         output_func = (sol, i) -> (sol.W.W[end], false))
+
+        solW_at_1 = solve(ensemble_probW, EM(), dt = 1 / 10, trajectories = 40_000)
+
+        @test mean(solW_at_1)≈expected_mean rtol=0.1
+        @test var(solW_at_1)≈expected_variance atol=0.1
+    end
+
+    @testset "BrownianBridge" begin
+        W = BrownianBridge(0.0, 1.0, 0.0, 1.0, nothing, nothing)
+
+        t = 1.0
+        expected_mean = 1.0
+        expected_variance = 0.0
+
+        meanW = mean(W.curW for i in 1:10_000 if reinit!(W, 0.0, t0 = t) === nothing)
+        varW = var(W.curW for i in 1:10_000 if reinit!(W, 0.0, t0 = t) === nothing)
+        @test meanW ≈ expected_mean rtol = 0.1
+        @test varW ≈ expected_variance atol = 0.1
+
+        prob = NoiseProblem(W, tspan)
+        ensemble_prob = EnsembleProblem(prob, output_func = (sol, i) -> (sol[end], false))
+        sol = solve(ensemble_prob, dt = 1 / 10, trajectories = 40_000)
+        @test mean(sol)≈expected_mean rtol=0.1
+        @test var(sol)≈expected_variance atol=0.1
+
+        prob = SDEProblem(f, g, 1.0, tspan, noise = W, save_noise = true)
+
+        ensemble_probW = EnsembleProblem(prob,
+                                         output_func = (sol, i) -> (sol.W.W[end], false))
+
+        solW_at_1 = solve(ensemble_probW, EM(), dt = 1 / 10, trajectories = 40_000)
+
+        @test mean(solW_at_1)≈expected_mean rtol=0.1
+        @test var(solW_at_1)≈expected_variance atol=0.1
+    end
+end

--- a/test/reinit_test.jl
+++ b/test/reinit_test.jl
@@ -13,8 +13,8 @@
 
         meanW = mean(W.curW for i in 1:10_000 if reinit!(W, 0.0, t0 = t) === nothing)
         varW = var(W.curW for i in 1:10_000 if reinit!(W, 0.0, t0 = t) === nothing)
-        @test meanW ≈ expected_mean atol = 0.1
-        @test varW ≈ expected_variance rtol = 0.1
+        @test meanW≈expected_mean atol=0.1
+        @test varW≈expected_variance rtol=0.1
 
         prob = NoiseProblem(W, tspan)
         ensemble_prob = EnsembleProblem(prob, output_func = (sol, i) -> (sol[end], false))
@@ -45,8 +45,8 @@
 
         meanW = mean(W.curW for i in 1:10_000 if reinit!(W, 0.0, t0 = t) === nothing)
         varW = var(W.curW for i in 1:10_000 if reinit!(W, 0.0, t0 = t) === nothing)
-        @test meanW ≈ expected_mean atol = 0.1
-        @test varW ≈ expected_variance rtol = 0.1
+        @test meanW≈expected_mean atol=0.1
+        @test varW≈expected_variance rtol=0.1
 
         prob = NoiseProblem(W, tspan)
         ensemble_prob = EnsembleProblem(prob, output_func = (sol, i) -> (sol[end], false))
@@ -78,8 +78,8 @@
 
         meanW = mean(W.curW for i in 1:10_000 if reinit!(W, 0.0, t0 = t) === nothing)
         varW = var(W.curW for i in 1:10_000 if reinit!(W, 0.0, t0 = t) === nothing)
-        @test meanW ≈ expected_mean atol = 0.1
-        @test varW ≈ expected_variance rtol = 0.1
+        @test meanW≈expected_mean atol=0.1
+        @test varW≈expected_variance rtol=0.1
 
         prob = NoiseProblem(W, tspan)
         ensemble_prob = EnsembleProblem(prob, output_func = (sol, i) -> (sol[end], false))
@@ -107,8 +107,8 @@
 
         meanW = mean(W.curW for i in 1:10_000 if reinit!(W, 0.0, t0 = t) === nothing)
         varW = var(W.curW for i in 1:10_000 if reinit!(W, 0.0, t0 = t) === nothing)
-        @test meanW ≈ expected_mean rtol = 0.1
-        @test varW ≈ expected_variance atol = 0.1
+        @test meanW≈expected_mean rtol=0.1
+        @test varW≈expected_variance atol=0.1
 
         prob = NoiseProblem(W, tspan)
         ensemble_prob = EnsembleProblem(prob, output_func = (sol, i) -> (sol[end], false))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,6 +25,7 @@ using Test
     include("two_processes.jl")
     include("extraction_test.jl")
     include("restart_test.jl")
+    include("reinit_test.jl")
     include("BWT_test.jl")
     include("pcn_test.jl")
 end


### PR DESCRIPTION
This fixes #126 and #131 .

The main thing is to adjust the initial state of the noise when the initial time of the problem is different from the initial time of the given noise.

Along the way, we had to address the reinitialization of bridge-type processes, that, after the first solve, emptied `W.S₁` and started to behave as the underlying noise without bridging. For that, we added a cache field `W.reinitS₁` to a `NoiseProcess` to cache the initial state of the noise.