### PR TITLE
add `cur_time` as a guess to `NoiseGrid` to speed up search for time point

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -19,9 +19,9 @@ jobs:
           - {user: SciML, repo: StochasticDiffEq.jl, group: Interface}
           - {user: SciML, repo: StochasticDiffEq.jl, group: Interface2}
           - {user: SciML, repo: StochasticDiffEq.jl, group: Interface3}
-          - {user: SciML, repo: DiffEqSensitivity.jl, group: SDE1}
-          - {user: SciML, repo: DiffEqSensitivity.jl, group: SDE2}
-          - {user: SciML, repo: DiffEqSensitivity.jl, group: SDE3}
+          - {user: SciML, repo: SciMLSensitivity.jl, group: SDE1}
+          - {user: SciML, repo: SciMLSensitivity.jl, group: SDE2}
+          - {user: SciML, repo: SciMLSensitivity.jl, group: SDE3}
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/src/noise_interfaces/noise_grid_interface.jl
+++ b/src/noise_interfaces/noise_grid_interface.jl
@@ -24,7 +24,7 @@ function interpolate!(W::NoiseGrid, t)
         error("Solution interpolation cannot extrapolate before the first timepoint. Build a longer NoiseGrid to cover the integration.")
     tdir = sign(ts[end] - ts[1])
 
-    W.cur_time[] += tdir
+    W.cur_time[] += 1
     W.cur_time[] = min(max(W.cur_time[], 1), length(ts)) # make sure it's inbounds
 
     # check if guess W.cur_time[] += tdir returned t correctly
@@ -76,7 +76,7 @@ function interpolate!(out1, out2, W::NoiseGrid, t)
 
     tdir = sign(ts[end] - ts[1])
 
-    W.cur_time[] += tdir
+    W.cur_time[] += 1
     W.cur_time[] = min(max(W.cur_time[], 1), length(ts)) # make sure it's inbounds
 
     # check if guess W.cur_time[] += tdir returned t correctly

--- a/src/noise_interfaces/noise_grid_interface.jl
+++ b/src/noise_interfaces/noise_grid_interface.jl
@@ -29,7 +29,9 @@ function interpolate!(W::NoiseGrid, t)
 
     # check if guess W.cur_time[] += tdir returned t correctly
     good_guess = (t isa Union{Rational, Integer} && ts[W.cur_time[]] == t) ||
-                 (isapprox(t, ts[W.cur_time[]]; atol = 100eps(typeof(t)), rtol = 100eps(t)))
+                 (!(t isa Union{Rational, Integer}) &&
+                  (isapprox(t, ts[W.cur_time[]]; atol = 100eps(typeof(t)),
+                            rtol = 100eps(t))))
 
     if good_guess
         @inbounds val1 = timeseries[W.cur_time[]]
@@ -79,7 +81,9 @@ function interpolate!(out1, out2, W::NoiseGrid, t)
 
     # check if guess W.cur_time[] += tdir returned t correctly
     good_guess = (t isa Union{Rational, Integer} && ts[W.cur_time[]] == t) ||
-                 (isapprox(t, ts[W.cur_time[]]; atol = 100eps(typeof(t)), rtol = 100eps(t)))
+                 (!(t isa Union{Rational, Integer}) &&
+                  (isapprox(t, ts[W.cur_time[]]; atol = 100eps(typeof(t)),
+                            rtol = 100eps(t))))
 
     if good_guess
         @inbounds copyto!(out1, timeseries[W.cur_time[]])

--- a/src/noise_interfaces/noise_grid_interface.jl
+++ b/src/noise_interfaces/noise_grid_interface.jl
@@ -24,26 +24,42 @@ function interpolate!(W::NoiseGrid, t)
         error("Solution interpolation cannot extrapolate before the first timepoint. Build a longer NoiseGrid to cover the integration.")
     tdir = sign(ts[end] - ts[1])
 
-    if t isa Union{Rational, Integer}
-        @inbounds i = searchsortedfirst(ts, t, rev = tdir < 0) # It's in the interval ts[i-1] to ts[i]
-    else
-        @inbounds i = searchsortedfirst(ts, t - tdir * 10eps(typeof(t)), rev = tdir < 0)
-    end
+    W.cur_time[] += tdir
 
-    @inbounds if (t isa Union{Rational, Integer} && ts[i] == t) ||
-                 (isapprox(t, ts[i]; atol = 100eps(typeof(t)), rtol = 100eps(t)))
-        val1 = timeseries[i]
-        timeseries2 !== nothing ? val2 = timeseries2[i] : val2 = nothing
-    elseif ts[i - 1] == t # Can happen if it's the first value!
-        val1 = timeseries[i - 1]
-        timeseries2 !== nothing ? val2 = timeseries2[i - 1] : val2 = nothing
+    # check if guess W.cur_time[] += tdir returned t correctly
+    good_guess = (t isa Union{Rational, Integer} && ts[W.cur_time[]] == t) ||
+                 (isapprox(t, ts[W.cur_time[]]; atol = 100eps(typeof(t)), rtol = 100eps(t)))
+
+    if good_guess
+        @inbounds val1 = timeseries[W.cur_time[]]
+        @inbounds timeseries2 !== nothing ? val2 = timeseries2[W.cur_time[]] :
+                  val2 = nothing
+    elseif ts[W.cur_time[] - 1] == t # Can happen if it's the first value!
+        val1 = timeseries[W.cur_time[] - 1]
+        timeseries2 !== nothing ? val2 = timeseries2[W.cur_time[] - 1] : val2 = nothing
     else
-        dt = ts[i] - ts[i - 1]
-        Θ = (t - ts[i - 1]) / dt
-        val1 = linear_interpolant(Θ, dt, timeseries[i - 1], timeseries[i])
-        timeseries2 !== nothing ?
-        val2 = linear_interpolant(Θ, dt, timeseries2[i - 1], timeseries2[i]) :
-        val2 = nothing
+        if t isa Union{Rational, Integer}
+            @inbounds i = searchsortedfirst(ts, t, rev = tdir < 0) # It's in the interval ts[i-1] to ts[i]
+        else
+            @inbounds i = searchsortedfirst(ts, t - tdir * 10eps(typeof(t)), rev = tdir < 0)
+        end
+        W.cur_time[] = i
+        @inbounds if (t isa Union{Rational, Integer} && ts[i] == t) ||
+                     (isapprox(t, ts[i]; atol = 100eps(typeof(t)), rtol = 100eps(t)))
+            # guess was wrong but still on grid
+            val1 = timeseries[i]
+            timeseries2 !== nothing ? val2 = timeseries2[i] : val2 = nothing
+        elseif ts[i - 1] == t # Can happen if it's the first value!
+            val1 = timeseries[i - 1]
+            timeseries2 !== nothing ? val2 = timeseries2[i - 1] : val2 = nothing
+        else
+            dt = ts[i] - ts[i - 1]
+            Θ = (t - ts[i - 1]) / dt
+            val1 = linear_interpolant(Θ, dt, timeseries[i - 1], timeseries[i])
+            timeseries2 !== nothing ?
+            val2 = linear_interpolant(Θ, dt, timeseries2[i - 1], timeseries2[i]) :
+            val2 = nothing
+        end
     end
     val1, val2
 end
@@ -54,27 +70,43 @@ function interpolate!(out1, out2, W::NoiseGrid, t)
         error("Solution interpolation cannot extrapolate past the final timepoint. Build a longer NoiseGrid to cover the integration.")
     sign(W.dt) * t < sign(W.dt) * (ts[1] - 10 * sign(W.dt) * eps(typeof(t))) &&
         error("Solution interpolation cannot extrapolate before the first timepoint. Build a longer NoiseGrid to cover the integration.")
+
     tdir = sign(ts[end] - ts[1])
 
-    if t isa Union{Rational, Integer}
-        @inbounds i = searchsortedfirst(ts, t, rev = tdir < 0) # It's in the interval ts[i-1] to ts[i]
-    else
-        @inbounds i = searchsortedfirst(ts, t - tdir * 10eps(typeof(t)), rev = tdir < 0)
-    end
+    W.cur_time[] += tdir
 
-    @inbounds if (t isa Union{Rational, Integer} && ts[i] == t) ||
-                 (isapprox(t, ts[i]; atol = 100eps(typeof(t)), rtol = 100eps(t)))
-        copyto!(out1, timeseries[i])
-        timeseries2 !== nothing && copyto!(out2, timeseries2[i])
-    elseif ts[i - 1] == t # Can happen if it's the first value!
-        copyto!(out1, timeseries[i - 1])
-        timeseries2 !== nothing && copyto!(out2, timeseries2[i - 1])
+    # check if guess W.cur_time[] += tdir returned t correctly
+    good_guess = (t isa Union{Rational, Integer} && ts[W.cur_time[]] == t) ||
+                 (isapprox(t, ts[W.cur_time[]]; atol = 100eps(typeof(t)), rtol = 100eps(t)))
+
+    if good_guess
+        @inbounds copyto!(out1, timeseries[W.cur_time[]])
+        @inbounds timeseries2 !== nothing && copyto!(out2, timeseries2[W.cur_time[]])
+    elseif ts[W.cur_time[] - 1] == t # Can happen if it's the first value!
+        copyto!(out1, timeseries[W.cur_time[] - 1])
+        timeseries2 !== nothing && copyto!(out2, timeseries2[W.cur_time[] - 1])
     else
-        dt = ts[i] - ts[i - 1]
-        Θ = (t - ts[i - 1]) / dt
-        linear_interpolant!(out1, Θ, dt, timeseries[i - 1], timeseries[i])
-        timeseries2 !== nothing &&
-            linear_interpolant!(out2, Θ, dt, timeseries2[i - 1], timeseries2[i])
+        if t isa Union{Rational, Integer}
+            @inbounds i = searchsortedfirst(ts, t, rev = tdir < 0) # It's in the interval ts[i-1] to ts[i]
+        else
+            @inbounds i = searchsortedfirst(ts, t - tdir * 10eps(typeof(t)), rev = tdir < 0)
+        end
+        W.cur_time[] = i
+        @inbounds if (t isa Union{Rational, Integer} && ts[i] == t) ||
+                     (isapprox(t, ts[i]; atol = 100eps(typeof(t)), rtol = 100eps(t)))
+            # guess was wrong but still on grid
+            copyto!(out1, timeseries[i])
+            timeseries2 !== nothing && copyto!(out2, timeseries2[i])
+        elseif ts[i - 1] == t # Can happen if it's the first value!
+            copyto!(out1, timeseries[i - 1])
+            timeseries2 !== nothing && copyto!(out2, timeseries2[i - 1])
+        else
+            dt = ts[i] - ts[i - 1]
+            Θ = (t - ts[i - 1]) / dt
+            linear_interpolant!(out1, Θ, dt, timeseries[i - 1], timeseries[i])
+            timeseries2 !== nothing &&
+                linear_interpolant!(out2, Θ, dt, timeseries2[i - 1], timeseries2[i])
+        end
     end
 end
 

--- a/src/noise_interfaces/noise_grid_interface.jl
+++ b/src/noise_interfaces/noise_grid_interface.jl
@@ -25,6 +25,7 @@ function interpolate!(W::NoiseGrid, t)
     tdir = sign(ts[end] - ts[1])
 
     W.cur_time[] += tdir
+    W.cur_time[] = min(max(W.cur_time[], 1), length(ts)) # make sure it's inbounds
 
     # check if guess W.cur_time[] += tdir returned t correctly
     good_guess = (t isa Union{Rational, Integer} && ts[W.cur_time[]] == t) ||
@@ -74,6 +75,7 @@ function interpolate!(out1, out2, W::NoiseGrid, t)
     tdir = sign(ts[end] - ts[1])
 
     W.cur_time[] += tdir
+    W.cur_time[] = min(max(W.cur_time[], 1), length(ts)) # make sure it's inbounds
 
     # check if guess W.cur_time[] += tdir returned t correctly
     good_guess = (t isa Union{Rational, Integer} && ts[W.cur_time[]] == t) ||


### PR DESCRIPTION
Improves the timing of NG by roughly 10x for the example in https://github.com/SciML/DiffEqNoiseProcess.jl/issues/140.
```julia
dt = 0.001

W = WienerProcess!(0.0, rand(2))
prob = NoiseProblem(W, (0.0, 1000.0))
sol = @btime solve(prob; dt=dt)

NG = NoiseGrid((sol.t), sol.u)
_prob = NoiseProblem(NG, (0.0, 1000.0))
_sol = @btime solve(_prob; dt=dt)

@test _sol.u ≈ sol.u

#  87.323 ms (1000095 allocations: 95.86 MiB)
#  56.537 ms (1000034 allocations: 91.55 MiB)
```

I thought initially that the idea could also be applied to `NoiseWrapper` but since `NoiseWrapper` uses the `interpolate!` function from the source noise process, e.g.

https://github.com/SciML/DiffEqNoiseProcess.jl/blob/0b4f6976f4905ee4cc4cc6b5cc5e6db3ddc3c4a0/src/noise_interfaces/noise_process_interface.jl#L338

it seems a bit less nice to keep track of a `cur_time`. 