### PR TITLE
Ou patch

### DIFF
--- a/src/ornstein_uhlenbeck.jl
+++ b/src/ornstein_uhlenbeck.jl
@@ -10,9 +10,9 @@ function (X::OrnsteinUhlenbeck)(dW, W, dt, u, p, t, rng) #dist
     else
         rand_val = wiener_randn(rng, typeof(dW))
     end
-    drift = X.μ .+ (W[end] .- X.μ) .* exp.(-X.Θ * dt)
+    drift = X.μ .+ (W.curW .- X.μ) .* exp.(-X.Θ * dt)
     diffusion = X.σ .* sqrt.((1 .- exp.(-2X.Θ * dt)) ./ (2X.Θ))
-    drift .+ rand_val .* diffusion .- W[end]
+    drift .+ rand_val .* diffusion .- W.curW
 end
 
 #=
@@ -59,8 +59,8 @@ end
 
 function (X::OrnsteinUhlenbeck!)(rand_vec, W, dt, u, p, t, rng) #dist!
     wiener_randn!(rng, rand_vec)
-    @.. rand_vec = X.μ + (W[end] - X.μ) * exp(-X.Θ * dt) +
-                   rand_vec * X.σ * sqrt((1 - exp.(-2 * X.Θ .* dt)) / (2 * X.Θ)) - W[end]
+    @.. rand_vec = X.μ + (W.curW - X.μ) * exp(-X.Θ * dt) +
+                   rand_vec * X.σ * sqrt((1 - exp.(-2 * X.Θ .* dt)) / (2 * X.Θ)) - W.curW
 end
 
 @doc doc"""

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,4 +28,5 @@ using Test
     include("reinit_test.jl")
     include("BWT_test.jl")
     include("pcn_test.jl")
+    include("savestep_test.jl")
 end

--- a/test/savestep_test.jl
+++ b/test/savestep_test.jl
@@ -1,0 +1,27 @@
+@testset "save_everystep Keyword" begin
+    #Test whether the result of the process is dependent on 'save_everystep'.
+    using DiffEqNoiseProcess, DiffEqBase, Test, Statistics, Random
+    processes = [   OrnsteinUhlenbeckProcess(1., 1., 0.3, 0., 0., nothing       ),
+                    WienerProcess(0.,0.,nothing                                 ),
+                    CorrelatedWienerProcess([1. 0.; 0. 1.],0.,[0.; 0.],nothing  ),
+                    GeometricBrownianMotionProcess(1., 1., 0., 0., nothing      )
+                ] 
+
+    
+
+    @testset "Noise_process = $(proc.dist)" for proc in processes
+        
+        cproc = deepcopy(proc)
+        cproc.save_everystep = true
+        prob = NoiseProblem(cproc, (0.0, 1.0); seed=1234)
+        sol_save = solve(prob; dt = 0.1)
+        
+
+        cproc = deepcopy(proc)
+        cproc.save_everystep = false
+        prob = NoiseProblem(cproc, (0.0, 1.0); seed=1234)
+        sol_nosave = solve(prob; dt = 0.1)
+        
+        @test sol_save.curW == sol_nosave.curW
+    end
+end


### PR DESCRIPTION
Fixed Typo in the [OrnsteinUhlbeckProcess](https://github.com/SciML/DiffEqNoiseProcess.jl/issues/150) .

Added Tests for such cases: `savestep_test.jl` where processes can be compated with and without the `save_everystep` option.