### PR TITLE
Add `reverse` dispatch for VBT

### DIFF
--- a/ext/DiffEqNoiseProcessReverseDiffExt.jl
+++ b/ext/DiffEqNoiseProcessReverseDiffExt.jl
@@ -4,19 +4,19 @@ using DiffEqNoiseProcess, DiffEqBase, Random
 isdefined(Base, :get_extension) ? (import ReverseDiff) : (import ..ReverseDiff)
 
 @inline function DiffEqNoiseProcess.wiener_randn(rng::Random.AbstractRNG,
-    proto::ReverseDiff.TrackedArray)
-ReverseDiff.track(convert.(eltype(proto.value), randn(rng, size(proto))))
+                                                 proto::ReverseDiff.TrackedArray)
+    ReverseDiff.track(convert.(eltype(proto.value), randn(rng, size(proto))))
 end
 @inline function DiffEqNoiseProcess.wiener_randn!(rng::AbstractRNG,
-     rand_vec::Array{<:ReverseDiff.TrackedReal
-                     })
-rand_vec .= ReverseDiff.track.(randn.((rng,), typeof.(DiffEqBase.value.(rand_vec))))
+                                                  rand_vec::Array{<:ReverseDiff.TrackedReal
+                                                                  })
+    rand_vec .= ReverseDiff.track.(randn.((rng,), typeof.(DiffEqBase.value.(rand_vec))))
 end
 @inline function DiffEqNoiseProcess.wiener_randn!(rng::AbstractRNG,
-     rand_vec::AbstractArray{
-                             <:ReverseDiff.TrackedReal
-                             })
-rand_vec .= ReverseDiff.track.(randn.((rng,), typeof.(DiffEqBase.value.(rand_vec))))
+                                                  rand_vec::AbstractArray{
+                                                                          <:ReverseDiff.TrackedReal
+                                                                          })
+    rand_vec .= ReverseDiff.track.(randn.((rng,), typeof.(DiffEqBase.value.(rand_vec))))
 end
 
 end

--- a/src/noise_interfaces/common.jl
+++ b/src/noise_interfaces/common.jl
@@ -226,3 +226,4 @@ function Base.reverse(W::AbstractNoiseProcess)
     end
     return backwardnoise
 end
+Base.reverse(W::VirtualBrownianTree) = W

--- a/src/wiener.jl
+++ b/src/wiener.jl
@@ -3,7 +3,8 @@ const one_over_sqrt2 = 1 / sqrt(2)
 @inline function wiener_randn(rng::AbstractRNG, proto::Array{T}) where {T}
     randn(rng, size(proto))
 end
-@inline function wiener_randn(rng::AbstractRNG, proto::T) where {T <: StaticArraysCore.SArray}
+@inline function wiener_randn(rng::AbstractRNG,
+                              proto::T) where {T <: StaticArraysCore.SArray}
     randn(rng, T)
 end
 @inline function wiener_randn(rng::AbstractRNG, proto)


### PR DESCRIPTION
See https://github.com/SciML/DiffEqNoiseProcess.jl/issues/152 

(In contrast to all other noise processes), we don't need to reverse the noise values for the VBT.
```julia
f = (u, p, t) -> 1.01u
g = (u, p, t) -> 0.11u
W = VirtualBrownianTree(-2.0, 0.0; tree_depth=6, tend=2.0)
dt = 1 / 2^8
prob1 = SDEProblem(f, g, 1.0, (0.0, 1.0), noise=W)
sol1 = solve(prob1, EM(), dt=dt, save_noise=true)
prob2 = SDEProblem(f, g, sol1(1.0), (1.0, 0.0), noise=W)
sol2 = solve(prob2, EM(), dt=dt, save_noise=true)
@test sol1.W.W ≈ sol2.W.W
@test sol2.u ≈ reverse(sol1.u) rtol = 0.01
```

So, I think 
```julia
Base.reverse(W::VirtualBrownianTree) = W
```
should fix it. @glatteis can you try if this will fix the issue with `BacksolveAdjoint` and `InterpolatingAdjoint` before we merge it? 