### PR TITLE
Use integer division in `split_VBT_seed`

### DIFF
--- a/src/noise_interfaces/virtual_brownian_tree_interface.jl
+++ b/src/noise_interfaces/virtual_brownian_tree_interface.jl
@@ -152,9 +152,9 @@ end
 function split_VBT_seed(rng::Random123.AbstractR123, parent_seed, current_depth, Nt)
 
     # seed left
-    seed_l = convert(typeof(parent_seed), parent_seed - (Nt - 1) / 2^(current_depth + 1))
+    seed_l = convert(typeof(parent_seed), parent_seed - (Nt - 1) ÷ 2^(current_depth + 1))
     # seed right
-    seed_r = convert(typeof(parent_seed), parent_seed + (Nt - 1) / 2^(current_depth + 1))
+    seed_r = convert(typeof(parent_seed), parent_seed + (Nt - 1) ÷ 2^(current_depth + 1))
 
     RandomNumbers.Random123.set_counter!(rng, parent_seed)
     return seed_l, seed_r, parent_seed


### PR DESCRIPTION
Sometimes the difference between two large integers in this computation with `/` is interpreted as a float, which can throw a `nested task error: InexactError: UInt64(1.5618062895e9)` (example number). This shouldn't change the meaning of the division (does it?) as both operands are powers of two.