### PR TITLE
fixed dispatch wiener_rand

### DIFF
--- a/src/wiener.jl
+++ b/src/wiener.jl
@@ -1,7 +1,8 @@
 const one_over_sqrt2 = 1 / sqrt(2)
 @inline wiener_randn(rng::AbstractRNG, ::Type{T}) where {T} = randn(rng, T)
-@inline function wiener_randn(rng::AbstractRNG, proto::Array{T}) where {T}
-    randn(rng, size(proto))
+
+@inline function wiener_randn(rng::AbstractRNG, proto::AbstractArray{T}) where {T<:Number}
+    randn(rng, T, size(proto))
 end
 @inline function wiener_randn(rng::AbstractRNG,
                               proto::T) where {T <: StaticArraysCore.SArray}
@@ -10,11 +11,7 @@ end
 @inline function wiener_randn(rng::AbstractRNG, proto)
     convert(typeof(proto), randn(rng, size(proto)))
 end
-@inline wiener_randn!(rng::AbstractRNG, rand_vec::Array) = randn!(rng, rand_vec)
-@inline function wiener_randn(y::AbstractRNG, ::Type{Complex{T}}) where {T}
-    convert(T, one_over_sqrt2) * (randn(y, T) + im * randn(y, T))
-end
-
+@inline wiener_randn!(rng::AbstractRNG, rand_vec::AbstractArray) = randn!(rng, rand_vec)
 @inline function wiener_randn!(rng::AbstractRNG, rand_vec)
     rand_vec .= Base.Broadcast.Broadcasted(randn, ())
 end


### PR DESCRIPTION
Solves the issue #156

Fixes Dispatch issue of  `function wiener_randn(rng::AbstractRNG, proto::Array{T}) where {T}` where this would always be invoked, even for complexvalued arrays.

Furthermore `Random.randn(Complex)` includes the normation factor `1/sqrt(2)`, such that no specialisation is nececcary.