### PR TITLE
Ou bridge

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,21 @@
+steps:
+  - label: "Bridge"
+    plugins:
+      - JuliaCI/julia#v1:
+          version: "1"
+      - JuliaCI/julia-test#v1:
+          coverage: true
+          julia_args: "--threads=auto"
+    agents:
+      os: "linux"
+      queue: "juliaecosystem"
+      arch: "x86_64"
+      exclusive: true
+    env:
+      GROUP: 'Shadowing'
+    timeout_in_minutes: 120
+    # Don't run Buildkite if the commit message includes the text [skip tests]
+    if: build.message !~ /\[skip tests\]/
+
+env:
+  JULIA_PKG_SERVER: "" # it often struggles with our large artifacts

--- a/src/DiffEqNoiseProcess.jl
+++ b/src/DiffEqNoiseProcess.jl
@@ -69,6 +69,8 @@ export CompoundPoissonProcess, CompoundPoissonProcess!
 
 export GeometricBrownianBridge, GeometricBrownianBridge!
 
+export OrnsteinUhlenbeckBridge, OrnsteinUhlenbeckBridge!
+
 export CompoundPoissonBridge, CompoundPoissonBridge!
 
 export OrnsteinUhlenbeckProcess, OrnsteinUhlenbeckProcess!

--- a/src/bridges.jl
+++ b/src/bridges.jl
@@ -97,3 +97,21 @@ function CompoundPoissonBridge!(rate, t0, tend, W0, Wh; kwargs...)
     push!(W.reinitS₁, (h, Wh, nothing))
     W
 end
+
+function OrnsteinUhlenbeckBridge(Θ, μ, σ, t0, tend, W0, Wend, Z0 = nothing; kwargs...)
+    ou = OrnsteinUhlenbeckProcess(Θ, μ, σ, t0, W0, Z0 = nothing; kwargs...)
+    h = tend - t0
+    Wh = Wend - W0
+    push!(ou.S₁, (h, Wh, nothing))
+    push!(ou.reinitS₁, (h, Wh, nothing))
+    ou
+end
+
+function OrnsteinUhlenbeckBridge!(Θ, μ, σ, t0, tend, W0, Wend, Z0 = nothing; kwargs...)
+    ou = OrnsteinUhlenbeckProcess!(Θ, μ, σ, t0, W0, Z0 = nothing; kwargs...)
+    h = tend - t0
+    Wh = Wend - W0
+    push!(ou.S₁, (h, Wh, nothing))
+    push!(ou.reinitS₁, (h, Wh, nothing))
+    ou
+end

--- a/src/bridges.jl
+++ b/src/bridges.jl
@@ -99,18 +99,18 @@ function CompoundPoissonBridge!(rate, t0, tend, W0, Wh; kwargs...)
 end
 
 function OrnsteinUhlenbeckBridge(Θ, μ, σ, t0, tend, W0, Wend, Z0 = nothing; kwargs...)
-    ou = OrnsteinUhlenbeckProcess(Θ, μ, σ, t0, W0, Z0 = nothing; kwargs...)
+    ou = OrnsteinUhlenbeckProcess(Θ, μ, σ, t0, W0, Z0; kwargs...)
     h = tend - t0
-    Wh = Wend - W0
+    Wh = Wend .- W0
     push!(ou.S₁, (h, Wh, nothing))
     push!(ou.reinitS₁, (h, Wh, nothing))
     ou
 end
 
 function OrnsteinUhlenbeckBridge!(Θ, μ, σ, t0, tend, W0, Wend, Z0 = nothing; kwargs...)
-    ou = OrnsteinUhlenbeckProcess!(Θ, μ, σ, t0, W0, Z0 = nothing; kwargs...)
+    ou = OrnsteinUhlenbeckProcess!(Θ, μ, σ, t0, W0, Z0; kwargs...)
     h = tend - t0
-    Wh = Wend - W0
+    Wh = Wend .- W0
     push!(ou.S₁, (h, Wh, nothing))
     push!(ou.reinitS₁, (h, Wh, nothing))
     ou

--- a/src/noise_interfaces/noise_process_interface.jl
+++ b/src/noise_interfaces/noise_process_interface.jl
@@ -413,14 +413,14 @@ end
             end
         else
             if reverse
-                W0, Wh = W.W[i], W.W[i - 1]
+                W0, Wh = W.W[i], W.W[i - 1] - W.W[i]
                 if W.Z !== nothing
                     Z0, Zh = W.Z[i + 1], W.Z[i]
                 end
                 h = W.t[i - 1] - W.t[i]
                 q = (t - W.t[i]) / h
             else
-                W0, Wh = W.W[i - 1], W.W[i]
+                W0, Wh = W.W[i - 1], W.W[i] - W.W[i-1]
                 if W.Z !== nothing
                     Z0, Zh = W.Z[i - 1], W.Z[i]
                 end
@@ -430,15 +430,15 @@ end
 
             if isinplace(W)
                 new_curW = similar(W.dW)
-                W.bridge(new_curW, W, W0, Wh, q, h, u, p, t, W.rng)
-                if iscontinuous(W)
-                    @. new_curW += (1 - q) * W0
-                else
-                    @. new_curW += W0
-                end
+                W.bridge(new_curW, W, W0, Wh, q, h, u, p, W.t[i-1], W.rng)
+                #if iscontinuous(W)
+                #    @. new_curW += (1 - q) * W0
+                #else
+                @. new_curW += W0
+                #end
                 if W.Z !== nothing
                     new_curZ = similar(W.dZ)
-                    W.bridge(new_curZ, W, Z0, Zh, q, h, u, p, t, W.rng)
+                    W.bridge(new_curZ, W, Z0, Zh, q, h, u, p, W.t[i-1], W.rng)
                     if iscontinuous(W)
                         @. new_curZ += (1 - q) * Z0
                     else
@@ -448,15 +448,15 @@ end
                     new_curZ = nothing
                 end
             else
-                new_curW = W.bridge(W.dW, W, W0, Wh, q, h, u, p, t, W.rng)
-                if iscontinuous(W)
+                new_curW = W.bridge(W.dW, W, W0, Wh, q, h, u, p, W.t[i-1], W.rng)
+                #if iscontinuous(W)
                     # This should actually be based on the function for computing the mean
                     # flow of the noise process, but for now we'll just handle Wiener and
                     # Poisson
-                    new_curW += (1 - q) * W0
-                else
+                #    new_curW += (1 - q) * W0
+                #else
                     new_curW += W0
-                end
+                #end
                 if W.Z !== nothing
                     new_curZ = W.bridge(W.dZ, W, Z0, Zh, q, h, u, p, t, W.rng)
                     if iscontinuous(W)

--- a/src/noise_interfaces/noise_process_interface.jl
+++ b/src/noise_interfaces/noise_process_interface.jl
@@ -439,11 +439,11 @@ end
                 if W.Z !== nothing
                     new_curZ = similar(W.dZ)
                     W.bridge(new_curZ, W, Z0, Zh, q, h, u, p, W.t[i-1], W.rng)
-                    if iscontinuous(W)
-                        @. new_curZ += (1 - q) * Z0
-                    else
+                    #if iscontinuous(W)
+                     #   @. new_curZ += (1 - q) * Z0
+                    #else
                         @. new_curZ += Z0
-                    end
+                    #end
                 else
                     new_curZ = nothing
                 end
@@ -458,12 +458,12 @@ end
                     new_curW += W0
                 #end
                 if W.Z !== nothing
-                    new_curZ = W.bridge(W.dZ, W, Z0, Zh, q, h, u, p, t, W.rng)
-                    if iscontinuous(W)
-                        new_curZ += (1 - q) * Z0
-                    else
+                    new_curZ = W.bridge(W.dZ, W, Z0, Zh, q, h, u, p, W.t[i-1], W.rng)
+                    #if iscontinuous(W)
+                    #    new_curZ += (1 - q) * Z0
+                    #else
                         new_curZ += Z0
-                    end
+                    #end
                 else
                     new_curZ = nothing
                 end

--- a/src/ornstein_uhlenbeck.jl
+++ b/src/ornstein_uhlenbeck.jl
@@ -27,18 +27,6 @@ r = Θμ
 https://arxiv.org/pdf/1011.0067.pdf page 18
 note that in the paper there is a typo in the formula for σ^2
 =#
-#=
-function ou_bridge(dW, ou, W, W0, Wh, q, h, u, p, t, rng)
-    #var = ou.σ^2/(2*ou.Θ) * (cosh(ou.Θ*h) - cosh(ou.Θ*(h - 2*h*q))) / sinh(ou.Θ*h) #following https://www.researchgate.net/publication/250917470_On_the_Pricing_of_Storable_Commodities 
-    var = ou.σ^2 * sinh(ou.Θ*(h*(1. -q))) * (sinh(ou.Θ*(q*h))) /( ou.Θ * sinh(ou.Θ * h))
-    #println("foo")
-    if typeof(dW) <: AbstractArray
-        @.  (W0-ou.μ)*(sinh(ou.Θ*(h*(1. -q)))/sinh(ou.Θ*h) - 1.) + (Wh+W0-ou.μ)*sinh(ou.Θ*q*h)/sinh(ou.Θ*h) + sqrt(var) * wiener_randn(rng, dW)
-    else
-            (W0-ou.μ)*(sinh(ou.Θ*(h*(1. -q)))/sinh(ou.Θ*h) - 1.) + (Wh+W0-ou.μ)*sinh(ou.Θ*q*h)/sinh(ou.Θ*h) + sqrt(var) * wiener_randn(rng, typeof(dW))
-    end
-end
-=#
 function ou_bridge(dW, ou, W, W0, Wh, q, h, u, p, t, rng)
     if typeof(dW) <: AbstractArray
         rand_vec = wiener_randn(rng, dW)

--- a/src/ornstein_uhlenbeck.jl
+++ b/src/ornstein_uhlenbeck.jl
@@ -27,21 +27,35 @@ r = Θμ
 https://arxiv.org/pdf/1011.0067.pdf page 18
 note that in the paper there is a typo in the formula for σ^2
 =#
-function ou_bridge(dW, ou, W, W0, Wh, q, h, u, p, t, rng) 
+#=
+function ou_bridge(dW, ou, W, W0, Wh, q, h, u, p, t, rng)
+    #var = ou.σ^2/(2*ou.Θ) * (cosh(ou.Θ*h) - cosh(ou.Θ*(h - 2*h*q))) / sinh(ou.Θ*h) #following https://www.researchgate.net/publication/250917470_On_the_Pricing_of_Storable_Commodities 
     var = ou.σ^2 * sinh(ou.Θ*(h*(1. -q))) * (sinh(ou.Θ*(q*h))) /( ou.Θ * sinh(ou.Θ * h))
-
+    #println("foo")
     if typeof(dW) <: AbstractArray
-        @. (W0-ou.μ)*(sinh(ou.Θ*(h*(1. -q)))/sinh(ou.Θ*h) - 1.) + (Wh+W0-ou.μ)*sinh(ou.Θ*q*h)/sinh(ou.Θ*h) + sqrt(var) * wiener_randn(rng, dW)
+        @.  (W0-ou.μ)*(sinh(ou.Θ*(h*(1. -q)))/sinh(ou.Θ*h) - 1.) + (Wh+W0-ou.μ)*sinh(ou.Θ*q*h)/sinh(ou.Θ*h) + sqrt(var) * wiener_randn(rng, dW)
     else
+            (W0-ou.μ)*(sinh(ou.Θ*(h*(1. -q)))/sinh(ou.Θ*h) - 1.) + (Wh+W0-ou.μ)*sinh(ou.Θ*q*h)/sinh(ou.Θ*h) + sqrt(var) * wiener_randn(rng, typeof(dW))
+    end
+end
+=#
+function ou_bridge(dW, ou, W, W0, Wh, q, h, u, p, t, rng)
+    if typeof(dW) <: AbstractArray
+        rand_vec = wiener_randn(rng, dW)
+        var = @.   ou.σ^2 * sinh(ou.Θ*(h*(1. -q))) * (sinh(ou.Θ*(q*h))) /( ou.Θ * sinh(ou.Θ * h))
+        @. (W0-ou.μ)*(sinh(ou.Θ*(h*(1. -q)))/sinh(ou.Θ*h) - 1.) + (Wh+W0-ou.μ)*sinh(ou.Θ*q*h)/sinh(ou.Θ*h) + sqrt(var) * rand_vec
+         
+    else
+        var = ou.σ^2 * sinh(ou.Θ*(h*(1. -q))) * (sinh(ou.Θ*(q*h))) /( ou.Θ * sinh(ou.Θ * h))
         (W0-ou.μ)*(sinh(ou.Θ*(h*(1. -q)))/sinh(ou.Θ*h) - 1.) + (Wh+W0-ou.μ)*sinh(ou.Θ*q*h)/sinh(ou.Θ*h) + sqrt(var) * wiener_randn(rng, typeof(dW))
     end
 end
 
-function ou_bridge!(rand_vec, ou, W, W0, Wh, q, h, u, p, t, rng) 
-    var = ou.σ^2 * sinh(ou.Θ*(h*(1. -q))) * (sinh(ou.Θ*(q*h))) /( ou.Θ * sinh(ou.Θ * h))
 
+
+function ou_bridge!(rand_vec, ou, W, W0, Wh, q, h, u, p, t, rng) 
     wiener_randn!(rng, rand_vec)
-    @.. (W0-ou.μ)*(sinh(ou.Θ*(h*(1. -q)))/sinh(ou.Θ*h) - 1.) + (Wh+W0-ou.μ)*sinh(ou.Θ*q*h)/sinh(ou.Θ*h) + sqrt(var) * rand_vec(rng, dW)
+    @.. rand_vec = (W0-ou.μ)*(sinh(ou.Θ*(h*(1. -q)))/sinh(ou.Θ*h) - 1.) + (Wh+W0-ou.μ)*sinh(ou.Θ*q*h)/sinh(ou.Θ*h) + sqrt(ou.σ^2 * sinh(ou.Θ*(h*(1. -q))) * (sinh(ou.Θ*(q*h))) /( ou.Θ * sinh(ou.Θ * h))) * rand_vec
 end
 
 @doc doc"""
@@ -98,5 +112,5 @@ OrnsteinUhlenbeckProcess!(Θ,μ,σ,t0,W0,Z0=nothing;kwargs...)
 """
 function OrnsteinUhlenbeckProcess!(Θ, μ, σ, t0, W0, Z0 = nothing; kwargs...)
     ou = OrnsteinUhlenbeck!(Θ, μ, σ)
-    NoiseProcess{true}(t0, W0, Z0, ou, nothing; kwargs...)
+    NoiseProcess{true}(t0, W0, Z0, ou, (rand_vec, W, W0, Wh, q, h, u, p, t, rng) -> ou_bridge!(rand_vec, ou , W, W0, Wh, q, h, u, p, t, rng); kwargs...)
 end

--- a/test/bridge_test.jl
+++ b/test/bridge_test.jl
@@ -71,3 +71,168 @@
     @test ≈(timestep_mean(sol, Int(2^(W.tree_depth) + 1))[1], W.W[end], atol = 1e-16)
     @test ≈(timestep_meanvar(sol, Int(2^(W.tree_depth) + 1))[2], 0.0, atol = 1e-16)
 end
+using DiffEqNoiseProcess, DiffEqBase, Test, Random, DiffEqBase.EnsembleAnalysis, Plots
+using StatsBase, Statistics
+
+@testset begin "Scalar Ou-Bridge"
+    p = plot()
+    sols_forward = []
+    dt = 0.125
+    t_max = 20.
+    n = Int(t_max / dt + 2)
+    st = []
+    Random.seed!(1234)
+    for i in 1:500_000
+        local ou = OrnsteinUhlenbeckProcess(1.5, .25, .2 , 0., 0.)
+        local prob = NoiseProblem(ou, (0.,t_max))
+        local s = solve(prob; dt = dt)   
+        push!(sols_forward, s.u)
+        if i == 1
+            global st = s.t
+        end
+    end
+
+    st2 = []
+    sols_interpolated = []
+    Random.seed!(1234)
+    ou = OrnsteinUhlenbeckProcess(1.5, .25, .2 , 0., 0.)
+    for i in 1:500_000
+        local prob = NoiseProblem(ou, (0.,t_max))
+        local s2 = solve(prob; dt = t_max)
+        s2.(st)
+        push!(sols_interpolated, s2.u)
+        if i == 1
+            global st2 = s2.t
+        end
+    end
+
+    Random.seed!(1234)
+    ou = OrnsteinUhlenbeckProcess(1.5, .25, .2, 0., 0.)
+    prob = NoiseProblem(ou, (0.,t_max))
+    sols_solver= []
+    st = []
+    for i in 1:500_000
+        local s = solve(prob; dt = t_max)
+        ou_bridge = OrnsteinUhlenbeckBridge(1.5, .25, .2, 0., t_max, 0., s.u[end])
+        s = solve(NoiseProblem(ou_bridge, (0.,t_max)); dt=0.125)
+        push!(sols_solver, s.u)
+        if i == 1
+            global st = s.t
+        end
+    end
+
+    @test all(isapprox.(mean(sols_forward), mean(sols_interpolated); atol=1e-3))
+    @test all(isapprox.(mean(sols_forward), mean(sols_solver); atol=1e-3))
+
+    @test all(isapprox.(std(sols_forward), std(sols_interpolated); atol=1e-3))
+    @test all(isapprox.(std(sols_forward), std(sols_solver); atol=1e-3))
+end
+
+@testset begin "Vector Ou-Bridge"
+    sols_forward = []
+    dt = 0.125
+    t_max = 20.
+    n = Int(t_max / dt + 2)
+    st = []
+    Random.seed!(1234)
+    ou = OrnsteinUhlenbeckProcess([1.5], [.25], [.2] , 0., [0.])
+    for i in 1:500_000
+        local prob = NoiseProblem(ou, (0.,t_max))
+        local s = solve(prob; dt = dt)   
+        push!(sols_forward, s.u)
+        if i == 1
+            global st = s.t
+        end
+    end
+    
+    st2 = []
+    sols_interpolated = []
+    Random.seed!(1234)
+    ou = OrnsteinUhlenbeckProcess([1.5], [.25], [.2] , 0., [0.])
+    for i in 1:500_000
+        local prob = NoiseProblem(ou, (0.,t_max))
+        local s2 = solve(prob; dt = t_max)
+        s2.(st)
+        push!(sols_interpolated, s2.u)
+        if i == 1
+            global st2 = s2.t
+        end
+    end
+    
+    Random.seed!(1234)
+    ou = OrnsteinUhlenbeckProcess([1.5], [.25], [.2], 0., [0.])
+    prob = NoiseProblem(ou, (0.,t_max))
+    sols_solver= []
+    st = []
+    println("------- bridge solver ---------")
+    for i in 1:500_000
+        local s = solve(prob; dt = t_max)
+        local ou_bridge = OrnsteinUhlenbeckBridge([1.5], [.25], [.2], 0., t_max, [0.], s.u[end])
+        local s = solve(NoiseProblem(ou_bridge, (0.,t_max)); dt=0.125)
+        push!(sols_solver, s.u)
+        if i == 1
+            global st = s.t
+        end
+    end
+
+    @test all(isapprox.(mean(sols_forward), mean(sols_interpolated); atol=1e-3))
+    @test all(isapprox.(mean(sols_forward), mean(sols_solver); atol=1e-3))
+    
+    @test all(isapprox.(std(sols_forward), std(sols_interpolated); atol=1e-3))
+    @test all(isapprox.(std(sols_forward), std(sols_solver); atol=1e-3))
+
+end
+
+@testset begin "Inplace OU-Bridge"
+    sols_forward = []
+    dt = 0.125
+    t_max = 20.
+    n = Int(t_max / dt + 2)
+    st = []
+    Random.seed!(1234)
+    ou = OrnsteinUhlenbeckProcess!([1.5], [.25], [.2] , 0., [0.])
+    for i in 1:500_000
+        local prob = NoiseProblem(ou, (0.,t_max))
+        local s = solve(prob; dt = dt)   
+        push!(sols_forward, s.u)
+        if i == 1
+            global st = s.t
+        end
+    end
+
+    st2 = []
+    sols_interpolated = []
+    Random.seed!(1234)
+    ou = OrnsteinUhlenbeckProcess!([1.5], [.25], [.2] , 0., [0.])
+    for i in 1:500_000
+        local prob = NoiseProblem(ou, (0.,t_max))
+        local s2 = solve(prob; dt = t_max)
+        s2.(st)
+        push!(sols_interpolated, s2.u)
+        if i == 1
+            global st2 = s2.t
+        end
+    end
+
+    Random.seed!(1234)
+    ou = OrnsteinUhlenbeckProcess!([1.5], [.25], [.2], 0., [0.])
+    prob = NoiseProblem(ou, (0.,t_max))
+    sols_solver= []
+    st = []
+    println("------- bridge solver ---------")
+    for i in 1:500_000
+        local s = solve(prob; dt = t_max)
+        local ou_bridge = OrnsteinUhlenbeckBridge!([1.5], [.25], [.2], 0., t_max, [0.], s.u[end])
+        local s = solve(NoiseProblem(ou_bridge, (0.,t_max)); dt=0.125)
+        push!(sols_solver, s.u)
+        if i == 1
+            global st = s.t
+        end
+    end
+
+    @test all(isapprox.(mean(sols_forward), mean(sols_interpolated); atol=1e-3))
+    @test all(isapprox.(mean(sols_forward), mean(sols_solver); atol=1e-3))
+    
+    @test all(isapprox.(std(sols_forward), std(sols_interpolated); atol=1e-3))
+    @test all(isapprox.(std(sols_forward), std(sols_solver); atol=1e-3))
+end

--- a/test/bridge_test.jl
+++ b/test/bridge_test.jl
@@ -71,11 +71,9 @@
     @test ≈(timestep_mean(sol, Int(2^(W.tree_depth) + 1))[1], W.W[end], atol = 1e-16)
     @test ≈(timestep_meanvar(sol, Int(2^(W.tree_depth) + 1))[2], 0.0, atol = 1e-16)
 end
-using DiffEqNoiseProcess, DiffEqBase, Test, Random, DiffEqBase.EnsembleAnalysis, Plots
-using StatsBase, Statistics
 
-@testset begin "Scalar Ou-Bridge"
-    p = plot()
+@testset "Scalar Ou-Bridge" begin
+    using DiffEqNoiseProcess, DiffEqBase, Test, Random, DiffEqBase.EnsembleAnalysis, StatsBase, Statistics
     sols_forward = []
     dt = 0.125
     t_max = 20.
@@ -88,7 +86,7 @@ using StatsBase, Statistics
         local s = solve(prob; dt = dt)   
         push!(sols_forward, s.u)
         if i == 1
-            global st = s.t
+            st = s.t
         end
     end
 
@@ -102,7 +100,7 @@ using StatsBase, Statistics
         s2.(st)
         push!(sols_interpolated, s2.u)
         if i == 1
-            global st2 = s2.t
+            st2 = s2.t
         end
     end
 
@@ -117,7 +115,7 @@ using StatsBase, Statistics
         s = solve(NoiseProblem(ou_bridge, (0.,t_max)); dt=0.125)
         push!(sols_solver, s.u)
         if i == 1
-            global st = s.t
+            st = s.t
         end
     end
 
@@ -128,7 +126,7 @@ using StatsBase, Statistics
     @test all(isapprox.(std(sols_forward), std(sols_solver); atol=1e-3))
 end
 
-@testset begin "Vector Ou-Bridge"
+@testset  "Vector Ou-Bridge" begin
     sols_forward = []
     dt = 0.125
     t_max = 20.
@@ -141,10 +139,10 @@ end
         local s = solve(prob; dt = dt)   
         push!(sols_forward, s.u)
         if i == 1
-            global st = s.t
+            st = s.t
         end
     end
-    
+
     st2 = []
     sols_interpolated = []
     Random.seed!(1234)
@@ -155,7 +153,7 @@ end
         s2.(st)
         push!(sols_interpolated, s2.u)
         if i == 1
-            global st2 = s2.t
+            st2 = s2.t
         end
     end
     
@@ -164,15 +162,24 @@ end
     prob = NoiseProblem(ou, (0.,t_max))
     sols_solver= []
     st = []
-    println("------- bridge solver ---------")
     for i in 1:500_000
         local s = solve(prob; dt = t_max)
         local ou_bridge = OrnsteinUhlenbeckBridge([1.5], [.25], [.2], 0., t_max, [0.], s.u[end])
         local s = solve(NoiseProblem(ou_bridge, (0.,t_max)); dt=0.125)
         push!(sols_solver, s.u)
         if i == 1
-            global st = s.t
+           st = s.t
         end
+    end
+    
+    sols_forward = map(sols_forward) do x
+        [y[1] for y in x]
+    end
+    sols_interpolated = map(sols_interpolated) do x
+        [y[1] for y in x]
+    end
+    sols_solver = map(sols_solver) do x
+        [y[1] for y in x]
     end
 
     @test all(isapprox.(mean(sols_forward), mean(sols_interpolated); atol=1e-3))
@@ -183,7 +190,7 @@ end
 
 end
 
-@testset begin "Inplace OU-Bridge"
+@testset  "Inplace OU-Bridge" begin
     sols_forward = []
     dt = 0.125
     t_max = 20.
@@ -196,7 +203,7 @@ end
         local s = solve(prob; dt = dt)   
         push!(sols_forward, s.u)
         if i == 1
-            global st = s.t
+           st = s.t
         end
     end
 
@@ -210,7 +217,7 @@ end
         s2.(st)
         push!(sols_interpolated, s2.u)
         if i == 1
-            global st2 = s2.t
+           st2 = s2.t
         end
     end
 
@@ -219,15 +226,24 @@ end
     prob = NoiseProblem(ou, (0.,t_max))
     sols_solver= []
     st = []
-    println("------- bridge solver ---------")
     for i in 1:500_000
         local s = solve(prob; dt = t_max)
         local ou_bridge = OrnsteinUhlenbeckBridge!([1.5], [.25], [.2], 0., t_max, [0.], s.u[end])
         local s = solve(NoiseProblem(ou_bridge, (0.,t_max)); dt=0.125)
         push!(sols_solver, s.u)
         if i == 1
-            global st = s.t
+            st = s.t
         end
+    end
+
+    sols_forward = map(sols_forward) do x
+        [y[1] for y in x]
+    end
+    sols_interpolated = map(sols_interpolated) do x
+        [y[1] for y in x]
+    end
+    sols_solver = map(sols_solver) do x
+        [y[1] for y in x]
     end
 
     @test all(isapprox.(mean(sols_forward), mean(sols_interpolated); atol=1e-3))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,32 +1,48 @@
-using Test
+
+using Test, Pkg
+
+const GROUP = get(ENV, "GROUP", "All")
+
+function activate_gpu_env()
+    Pkg.activate("gpu")
+    Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
+    Pkg.instantiate()
+end
 
 @time begin
-    include("interpolation_test.jl")
-    include("RSwM1_test.jl")
-    include("RSwM2_test.jl")
-    include("RSwM3_test.jl")
-    include("correlated.jl")
-    include("noise_wrapper.jl")
-    include("noise_function.jl")
-    include("noise_transport.jl")
-    include("copy_noise_test.jl")
-    include("VBT_test.jl")
-    include("noise_grid.jl")
-    include("noise_approximation.jl")
-    include("sde_noise_wrapper.jl")
-    include("multi_dim.jl")
-    include("geometric_bm.jl")
-    include("compoundpoisson.jl")
-    include("ornstein.jl")
-    include("bridge_test.jl")
-    include("ensemble_test.jl")
-    include("sde_adaptivedistribution_tests.jl")
-    include("reversal_test.jl")
-    include("two_processes.jl")
-    include("extraction_test.jl")
-    include("restart_test.jl")
-    include("reinit_test.jl")
-    include("BWT_test.jl")
-    include("pcn_test.jl")
-    include("savestep_test.jl")
+    if GROUP == "All" || GROUP == "Core1"
+        include("interpolation_test.jl")
+        include("RSwM1_test.jl")
+        include("RSwM2_test.jl")
+        include("RSwM3_test.jl")
+        include("correlated.jl")
+        include("noise_wrapper.jl")
+        include("noise_function.jl")
+        include("noise_transport.jl")
+        include("copy_noise_test.jl")
+        include("VBT_test.jl")
+        include("noise_grid.jl")
+        include("noise_approximation.jl")
+        include("sde_noise_wrapper.jl")
+        include("multi_dim.jl")
+        include("geometric_bm.jl")
+        include("compoundpoisson.jl")
+        include("ornstein.jl")
+        include("ensemble_test.jl")
+        include("sde_adaptivedistribution_tests.jl")
+        include("reversal_test.jl")
+        include("two_processes.jl")
+        include("extraction_test.jl")
+        include("restart_test.jl")
+        include("reinit_test.jl")
+        include("BWT_test.jl")
+        include("pcn_test.jl")
+        include("savestep_test.jl")
+    end
+
+    if GROUP == "All" || GROUP == "Bridge"
+        include("bridge_test.jl")
+    end
 end
+
+


### PR DESCRIPTION
This implements the Ornstein Uhlenbeck Bridge as in `https://arxiv.org/pdf/1011.0067.pdf%20page%2018.pdf`

Furthermore there was some issues in the `interpolate!` function;

- `Wh` was calculated as `W[i]` and `W[i-1]` respectively (forward, backward) meaning it is the value of W at the end of a step. This is inconsistent with  the way `solve` calls the bridges. (Where Wh corresponds to Wend-W0)
- the update of `W` conditioned  on `continous(W)` was leading to wrong and inconsistent results compared to `solve`.  The way the bridges are implemented are as a forward step, right? 
- `interpolate!` calls the bridge at `t=t_end`. While I think no bridge uses `t`, for consistency with solve I changed it to `t0`

-- none of these changes broke any tests

If these changes are sense full, they should also be applied to `Z` I guess.

 