### PR TITLE
Geometric brownian bridge fix

### DIFF
--- a/src/geometric_bm.jl
+++ b/src/geometric_bm.jl
@@ -27,14 +27,23 @@ https://math.stackexchange.com/questions/412470/conditional-distribution-in-brow
 =#
 function gbm_bridge(dW, gbm, W, W0, Wh, q, h, u, p, t, rng)
     if dW isa AbstractArray
-        return gbm.σ * sqrt((1 - q) * q * abs(h)) * wiener_randn(rng, dW) + q * Wh
+        gbb_mean = @.. log(W0) + q * (log(W0 + Wh) - log(W0))
+        gbb_std = sqrt((1 - q) * q * abs(h)) * gbm.σ
+
+        x = gbb_mean + gbb_std * wiener_randn(rng, dW)
+        return exp.(x) - W0
     else
-        return gbm.σ * sqrt((1 - q) * q * abs(h)) * wiener_randn(rng, typeof(dW)) + q * Wh
+        gbb_mean = log(W0) + q * (log(W0+Wh) - log(W0))
+        gbb_std = sqrt((1 - q) * q * abs(h)) * gbm.σ
+
+        x = gbb_mean + gbb_std * wiener_randn(rng, typeof(dW))
+        return exp(x) - W0
     end
 end
 function gbm_bridge!(rand_vec, gbm, W, W0, Wh, q, h, u, p, t, rng)
     wiener_randn!(rng, rand_vec)
-    @.. rand_vec = gbm.σ * sqrt((1 - q) * q * abs(h)) * rand_vec + q * Wh
+    @.. rand_vec = gbm.σ * sqrt((1 - q) * q * abs(h)) * rand_vec + (log(W0) + q * (log(W0 + Wh) - log(W0)))
+    @.. rand_vec = exp(rand_vec) - W0
 end
 
 @doc doc"""


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
  
## Additional context

Fixes https://github.com/SciML/DiffEqNoiseProcess.jl/issues/186.  The bridge distribution for the Geometric Brownian motion is [log-normal](https://en.wikipedia.org/wiki/Log-normal_distribution). @vwiela thanks for pointing this out and for preparing the great MWE (sorry this took so long)!
