### PR TITLE
Use RV at initialization in NoiseTransport

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -836,13 +836,26 @@ function NoiseTransport(t0, W, RV, rv, Z = nothing;
         rng = Xorshifts.Xoroshiro128Plus(rand(UInt64)), reset = true,
         reseed = true, kwargs...)
     iip = DiffEqBase.isinplace(W, 5)
+
+    if rv isa AbstractArray
+        RV(rng, rv)
+    else
+        rv = RV(rng)
+    end
+
     NoiseTransport{iip}(t0, W, RV, rv, Z; rng, reset, reseed, kwargs...)
 end
 
 function NoiseTransport(t0, W, RV; rng = Xorshifts.Xoroshiro128Plus(rand(UInt64)),
         reset = true, reseed = true, kwargs...)
     iip = DiffEqBase.isinplace(W, 5)
-    rv = RV(rng)
+
+    if rv isa AbstractArray
+        RV(rng, rv)
+    else
+        rv = RV(rng)
+    end
+
     Z = nothing
     NoiseTransport{iip}(t0, W, RV, rv, Z; rng, reset, reseed, kwargs...)
 end


### PR DESCRIPTION
Addresses https://github.com/SciML/DiffEqNoiseProcess.jl/issues/197

```julia
using DiffEqNoiseProcess, JuliaFormatter, StochasticDiffEq, Plots, Random, Distributions

# taken from the first examples about SDE in the doc (https://docs.sciml.ai/DiffEqDocs/stable/tutorials/sde_example/#Example-1:-Scalar-SDEs)
function lorenz(du, u, p, t)
    du[1] = 10.0(u[2] - u[1])
    du[2] = u[1] * (28.0 - u[3]) - u[2]
    du[3] = u[1] * u[2] - (8 / 3) * u[3]
end

function σ_lorenz(du, u, p, t)
    du[1] = 5.0
    du[2] = 5.0
    du[3] = 5.0
end

#taken from the doc about abstract noise processes
function f!(out, u, p, t, v)
    @show out # to check if noise is generated correctly
    @show v
    out[1] = sin(v[1] * t)
    out[2] = sin(t + v[2])
    out[3] = cos(t) * v[1] + sin(t) * v[2]
    nothing
end

function RV!(rng, v)
    @show v
    v[1] = randn(rng)
    v[2] = rand(rng)
    @show v
    nothing
end

rv = zeros(2)
t0 = 0.0
W = NoiseTransport(t0, f!, RV!, rv, noise_prototype=zeros(3))

# solving
prob_sde_lorenz = SDEProblem(lorenz, σ_lorenz, [1.0, 0.0, 0.0], (0.0, 1.0), noise=W)
sol = solve(prob_sde_lorenz, EM(), dt=0.01)
plot(sol, idxs=(1, 2, 3))
```
The values of `v` are indeed zero for the first run of the SDE solver. This seems to be a bug. For later runs, they do get initialized by `reinit! `
https://github.com/SciML/StochasticDiffEq.jl/pull/502/files#diff-ca1c45d4f0bec64e8340981f6b27f4037bf6ac13c8f1af132656c485c0a8e941R422

An easy fix (?) seems to be to force initialization in the constructor. This is already done for oop/scalar processes but not for inplace/array-like random variables (see changes below). Given that the [docs](https://docs.sciml.ai/DiffEqNoiseProcess/stable/abstract_noise_processes/#DiffEqNoiseProcess.NoiseTransport) say:
> The random variable can be either out-of-place or in-place. It is assumed it is out-of-place when the realization is a subtype of Number, and in-place, when it is a subtype of AbstractArray...

I think the fix below should be fine.

@rmsrosa could you have a look at this change as well, please? I haven't used `NoiseTransport` myself yet...and I am not fully confident I oversee all potential difficulties.

## Checklist

- [ ] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
