### PR TITLE
Remove outdated Julia v1.6 version check

### DIFF
--- a/test/noise_wrapper.jl
+++ b/test/noise_wrapper.jl
@@ -284,15 +284,9 @@ end
     save_noise = true
     _seed = 0x952197dfddfdce1f
 
-    if VERSION > v"1.6"
-        W = WienerProcess(t, rand_prototype,
-            save_everystep = save_noise,
-            rng = Xorshifts.Xoroshiro128Plus(_seed))
-    else
-        W = WienerProcess(t, rand_prototype,
-            save_everystep = save_noise,
-            rng = MersenneTwisters.MT19937(_seed))
-    end
+    W = WienerProcess(t, rand_prototype,
+        save_everystep = save_noise,
+        rng = Xorshifts.Xoroshiro128Plus(_seed))
     prob = NoiseProblem(W, (0.0, 1.0))
     W2 = solve(prob; dt = 0.1)
     bW = DiffEqNoiseProcess.vec_NoiseProcess(W2)


### PR DESCRIPTION
## Summary
Since Julia v1.10 is now the LTS, the version check for v1.6 is no longer needed.

## Changes
- Removed conditional RNG selection in test/noise_wrapper.jl
- Now always uses Xoroshiro128Plus instead of falling back to MT19937 for older Julia versions

## Test plan
- [ ] Tests pass locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/code)