### PR TITLE
don't overwrite RNG

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DiffEqNoiseProcess"
 uuid = "77a26b50-5914-5dd7-bc55-306e6241c503"
-version = "5.26.0"
+version = "5.26.1"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -8,7 +8,8 @@ Solve a noise problem by simulating the noise process over the specified time sp
 - `dt`: The time step size (required, no default)
 
 ## Keyword Arguments
-- `seed`: Random seed for reproducible results
+- `seed`: Random seed for reproducible results. If `0` (the default), will use the RNG
+    from the `NoiseProcess` or `NoiseTransport`.
 - Additional keyword arguments are passed to the underlying solver
 
 ## Returns
@@ -33,8 +34,6 @@ function DiffEqBase.__solve(
     if W isa Union{NoiseProcess, NoiseTransport}
         if prob.seed != 0
             Random.seed!(W.rng, prob.seed)
-        else
-            Random.seed!(W.rng, rand(UInt64))
         end
     end
     if W.reset


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

This is a suggested fix for #249.  I'm getting test failures that seem unrelated.  Most (all?) existing tests use `Random.seed!` so this shouldn't affect those one way or another.   We can either add tests here or change some of the `Random.seed!`.

Technically I suppose this is slightly breaking.
