### PR TITLE
Fix SciMLBase v3 breaking changes and bump version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DiffEqNoiseProcess"
 uuid = "77a26b50-5914-5dd7-bc55-306e6241c503"
-version = "5.28.0"
+version = "5.29.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]
@@ -40,7 +40,7 @@ RecipesBase = "0.7, 0.8, 1.0"
 RecursiveArrayTools = "2, 3, 4"
 ResettableStacks = "0.6, 1.0"
 ReverseDiff = "1"
-SciMLBase = "1, 2"
+SciMLBase = "2, 3"
 StaticArraysCore = "1.4"
 Statistics = "1"
 julia = "1.10"

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -23,7 +23,7 @@ sol = solve(prob; dt = 0.01)
 """
 function DiffEqBase.__solve(
         prob::AbstractNoiseProblem,
-        args::Union{Nothing, SciMLBase.DEAlgorithm}...; dt = 0.0,
+        args::Union{Nothing, SciMLBase.AbstractDEAlgorithm}...; dt = 0.0,
         kwargs...
     )
     if dt == 0.0 || dt == nothing


### PR DESCRIPTION
## Summary
- Replace removed `SciMLBase.DEAlgorithm` with `SciMLBase.AbstractDEAlgorithm` in `src/solve.jl`
- Update SciMLBase compat bounds from `"1, 2"` to `"2, 3"`
- Bump package version from 5.28.0 to 5.29.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)