### PR TITLE
Bump SciMLBase compat to include v3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DiffEqNoiseProcess"
 uuid = "77a26b50-5914-5dd7-bc55-306e6241c503"
-version = "5.28.0"
+version = "5.29.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]
@@ -40,7 +40,7 @@ RecipesBase = "0.7, 0.8, 1.0"
 RecursiveArrayTools = "2, 3, 4"
 ResettableStacks = "0.6, 1.0"
 ReverseDiff = "1"
-SciMLBase = "1, 2"
+SciMLBase = "1, 2, 3"
 StaticArraysCore = "1.4"
 Statistics = "1"
 julia = "1.10"

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -23,7 +23,7 @@ sol = solve(prob; dt = 0.01)
 """
 function DiffEqBase.__solve(
         prob::AbstractNoiseProblem,
-        args::Union{Nothing, SciMLBase.DEAlgorithm}...; dt = 0.0,
+        args::Union{Nothing, SciMLBase.AbstractDEAlgorithm}...; dt = 0.0,
         kwargs...
     )
     if dt == 0.0 || dt == nothing


### PR DESCRIPTION
## Summary
- Allow SciMLBase v3 (`SciMLBase = "1, 2, 3"`).
- Replace the one `SciMLBase.DEAlgorithm` reference in `src/solve.jl` with `SciMLBase.AbstractDEAlgorithm` — v3 removed the `DEAlgorithm` alias (SciMLBase v3 README: "Removed deprecated.jl: old type aliases (DEAlgorithm, DEProblem, DESolution, …)").
- Bump version to 5.29.0.

## Why
Unblocks the OrdinaryDiffEq v7 branch (SciML/OrdinaryDiffEq.jl#3419), which now pins `SciMLBase = "3"`. DiffEqNoiseProcess is pulled transitively through DiffEqDevTools / StochasticDiffEq in that test matrix, so every v7 test job is currently failing at Pkg.resolve on this package.

## Test plan
- [ ] CI on this PR (no code behavior changed — just the abstract type name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)