### PR TITLE
Bump DiffEqBase compat to include v7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DiffEqNoiseProcess"
 uuid = "77a26b50-5914-5dd7-bc55-306e6241c503"
-version = "5.29.0"
+version = "5.30.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]
@@ -30,7 +30,7 @@ DiffEqNoiseProcessReverseDiffExt = "ReverseDiff"
 
 [compat]
 CommonSolve = "0.2.6"
-DiffEqBase = "6.61"
+DiffEqBase = "6.61, 7"
 Distributions = "0.22, 0.23, 0.24, 0.25"
 GPUArraysCore = "0.1, 0.2"
 Optim = "1, 2"


### PR DESCRIPTION
## Summary

Allow `DiffEqBase = "6.61, 7"` so DiffEqNoiseProcess can be installed alongside the in-development DiffEqBase 7.0.0 (which ships as part of the OrdinaryDiffEq.jl v7 release, currently at `lib/DiffEqBase` in the OrdinaryDiffEq monorepo). Bumps 5.29.0 → 5.30.0.

## Motivation

On SciML/OrdinaryDiffEq.jl#3488 (the v7 release branch), essentially every test group (`Integrators_{I,II}`, `AlgConvergence_{I..III}`, `Regression_{I,II}`, `Interface{I..V}`, `AD`, `ModelingToolkit`, `Downstream`, `QA`, the whole sublibrary matrix) and the `build` job fail during resolution with:

```
ERROR: LoadError: Unsatisfiable requirements detected for package DiffEqNoiseProcess [77a26b50]:
 DiffEqNoiseProcess [77a26b50] log:
 ├─possible versions are: 2.0.0 - 5.29.0 or uninstalled
 ├─restricted to versions 5 by DiffEqDevTools [f3b72e0c], leaving only versions: 5.0.0 - 5.29.0
 │ └─DiffEqDevTools [f3b72e0c] log:
 │   ├─possible versions are: 2.53.0 or uninstalled
 │   └─DiffEqDevTools [f3b72e0c] is fixed to version 2.53.0
 └─restricted by compatibility requirements with DiffEqBase [2b5f629d] to versions: uninstalled — no versions left
   └─DiffEqBase [2b5f629d] log:
     ├─possible versions are: 7.0.0 or uninstalled
     ├─restricted to versions 7 by OrdinaryDiffEqTsit5 [b1df2697], leaving only versions: 7.0.0
     └─DiffEqBase [2b5f629d] is fixed to version 7.0.0
```

The monorepo's `lib/DiffEqDevTools` is dev'ed into every test env, and it transitively depends on DiffEqNoiseProcess, which is pulled from the General registry. The registered 5.29.0 caps `DiffEqBase` at `"6.61"`, which then excludes the 7.0.0 that every OrdinaryDiffEq v7 sublibrary requires. This PR widens that cap.

## Why this is source-level safe

DiffEqNoiseProcess's DiffEqBase surface is narrow and entirely stable across the v7 rename:

- Imports `DiffEqBase.isinplace`, `DiffEqBase.__solve`, `DiffEqBase.ODE_DEFAULT_NORM`, `DiffEqBase.has_reinit`, `DiffEqBase.reinit!`, `DiffEqBase.AbstractNoiseProcess`, `DiffEqBase.DEIntegrator`, `DiffEqBase.AbstractNoiseProblem`, `DiffEqBase.AbstractDEAlgorithm`, and `DiffEqBase.@..` — every one of these is still present and re-exported in `lib/DiffEqBase/src/DiffEqBase.jl` under v7.0.0.
- None of the symbols removed in the v7 NEWS appear in the codebase: grepped `src/` and `ext/` for `has_destats`, `RECOMPILE_BY_DEFAULT`, `fastpow`, `DEStats`, `concrete_solve`, `u_modified!`, `QuadratureProblem`, `.destats`, `DEAlgorithm`/`DEProblem`/`DESolution` (standalone, not `Abstract…`), `tuples()`/`intervals()` — zero matches. The only hit in the noise-matching grep is `AbstractDEAlgorithm` in `src/solve.jl:26`, which is the renamed (non-removed) abstract type.
- `@..` comes in through DiffEqBase's `using FastBroadcast: @.., Serial, Threaded` — still there in v7 (FastBroadcast just swapped out `True`/`False` for `Serial`/`Threaded`, not `@..`). The 5 uses of `@..` in `src/wiener.jl` all still compile.

## Verified locally

On Julia 1.11, with `lib/DiffEqBase` v7.0.0 `dev`-ed from the OrdinaryDiffEq monorepo into DiffEqNoiseProcess:

- `using DiffEqBase; DiffEqBase.pkgversion(DiffEqBase)` → `v"7.0.0"`
- `using DiffEqNoiseProcess; DiffEqNoiseProcess.pkgversion(DiffEqNoiseProcess)` → `v"5.30.0"`
- `WienerProcess(0.0, 0.0)` constructs and pretty-prints.

## Test plan

- [x] Source grep for every symbol removed in DiffEqBase v7 / SciMLBase v3 — no call sites.
- [x] Local load + `WienerProcess` construction against `lib/DiffEqBase` v7.0.0.
- [ ] CI on this PR (against registered DiffEqBase 6.x — source unchanged; expected green).
- [ ] OrdinaryDiffEq.jl#3488 resolver: `Unsatisfiable requirements detected for package DiffEqNoiseProcess` should disappear once this is released.

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>