### PR TITLE
Bump compat for OrdinaryDiffEq v7 / SciMLBase v3 ecosystem

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqNoiseProcess"
 uuid = "77a26b50-5914-5dd7-bc55-306e6241c503"
-version = "5.30.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
+version = "5.30.0"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
@@ -43,6 +43,7 @@ ReverseDiff = "1"
 SciMLBase = "1, 2, 3"
 StaticArraysCore = "1.4"
 Statistics = "1"
+StochasticDiffEq = "6, 7"
 julia = "1.10"
 
 [extras]

--- a/test/bridge_test.jl
+++ b/test/bridge_test.jl
@@ -67,7 +67,7 @@
 
     W = VirtualBrownianTree(0.0, 0.0; Wend = 1.0, tree_depth = 3)
     prob = NoiseProblem(W, (0.0, 1.0))
-    function prob_func(prob, i, repeat)
+    function prob_func(prob, ctx)
         # to re-instantiate PRNG
         Wtmp = VirtualBrownianTree(0.0, 0.0; Wend = 1.0, tree_depth = 3)
         remake(prob, noise = Wtmp)

--- a/test/compoundpoisson.jl
+++ b/test/compoundpoisson.jl
@@ -28,7 +28,7 @@
     u0 = 1.0
     expected_mean = 1 + t * r
     expected_variance = t * r
-    ensemble_prob = EnsembleProblem(prob; output_func = (sol, i) -> (sol.u[end], false))
+    ensemble_prob = EnsembleProblem(prob; output_func = (sol, ctx) -> (sol.u[end], false))
     sol = solve(ensemble_prob; dt = 0.1, trajectories = 40000)
     @test abs(mean(sol) - expected_mean) < 0.4
     @test abs(var(sol) - expected_variance) < 0.4 # Converges slowly
@@ -38,7 +38,7 @@
     prob = NoiseProblem(W, (0.0, 1.0))
     sol = solve(prob; dt = 0.1)
 
-    ensemble_prob = EnsembleProblem(prob; output_func = (sol, i) -> (sol.u[end], false))
+    ensemble_prob = EnsembleProblem(prob; output_func = (sol, ctx) -> (sol.u[end], false))
     sol = solve(ensemble_prob; dt = 0.1, trajectories = 40000)
     @test abs(mean(sol) - expected_mean) < 0.4
     @test abs(var(sol) - expected_variance) < 0.4 # Converges slowly

--- a/test/correlated.jl
+++ b/test/correlated.jl
@@ -31,7 +31,7 @@ using StaticArrays
     prob = NoiseProblem(W, (0.0, 1.0))
     sol = solve(prob; dt = 0.01)
 
-    output_func = (sol, i) -> (sol.dW, false)
+    output_func = (sol, ctx) -> (sol.dW, false)
     ensemble_prob = EnsembleProblem(prob, output_func = output_func)
     @time sol = Array(solve(ensemble_prob, dt = dt, trajectories = 1_000_000))
 

--- a/test/geometric_bm.jl
+++ b/test/geometric_bm.jl
@@ -29,7 +29,7 @@
     u0 = 1.0
     expected_mean = u0 * exp(μ * t)
     expected_variance = u0^2 * exp(2μ * t) * (exp(σ^2 * t) - 1)
-    ensemble_prob = EnsembleProblem(prob; output_func = (sol, i) -> (sol.u[end], false))
+    ensemble_prob = EnsembleProblem(prob; output_func = (sol, ctx) -> (sol.u[end], false))
     sol = solve(ensemble_prob; dt = 0.1, trajectories = 40000)
     @test abs(mean(sol) - expected_mean) < 0.4
     #abs(var(sol) - expected_variance) < 0.4 # Converges slowly

--- a/test/ornstein.jl
+++ b/test/ornstein.jl
@@ -12,7 +12,7 @@
     u0 = 2.0
     expected_mean = μ + (u0 - μ) * exp(-Θ * t)
     expected_variance = (1 - exp(-2Θ * t)) * σ^2 / (2Θ)
-    ensemble_prob = EnsembleProblem(prob; output_func = (sol, i) -> (sol.u[end], false))
+    ensemble_prob = EnsembleProblem(prob; output_func = (sol, ctx) -> (sol.u[end], false))
     sol = solve(ensemble_prob; dt = 0.1, trajectories = 10000)
     @test abs(mean(sol) - expected_mean) < 0.04
     @test abs(var(sol) - expected_variance) < 0.04

--- a/test/pcn_test.jl
+++ b/test/pcn_test.jl
@@ -102,7 +102,7 @@
     prob = NoiseProblem(W, (0.0, 1.0))
     sol = solve(prob, dt = 0.1)
 
-    function prob_func(prob, i, repeat)
+    function prob_func(prob, ctx)
         _sol = deepcopy(sol)
         Wtmp = pCN!(_sol, 1.0)
         remake(prob, noise = Wtmp)

--- a/test/reinit_test.jl
+++ b/test/reinit_test.jl
@@ -17,7 +17,7 @@
         @test varW ≈ expected_variance rtol = 0.1
 
         prob = NoiseProblem(W, tspan)
-        ensemble_prob = EnsembleProblem(prob, output_func = (sol, i) -> (sol.u[end], false))
+        ensemble_prob = EnsembleProblem(prob, output_func = (sol, ctx) -> (sol.u[end], false))
         sol = solve(ensemble_prob, dt = 1 / 10, trajectories = 40_000)
         @test mean(sol) ≈ expected_mean atol = 0.1
         @test var(sol) ≈ expected_variance atol = 0.1
@@ -26,7 +26,7 @@
 
         ensemble_probW = EnsembleProblem(
             prob,
-            output_func = (sol, i) -> (sol.W.W[end], false)
+            output_func = (sol, ctx) -> (sol.W.W[end], false)
         )
 
         solW_at_1 = solve(ensemble_probW, EM(), dt = 1 / 10, trajectories = 40_000)
@@ -51,7 +51,7 @@
         @test varW ≈ expected_variance rtol = 0.1
 
         prob = NoiseProblem(W, tspan)
-        ensemble_prob = EnsembleProblem(prob, output_func = (sol, i) -> (sol.u[end], false))
+        ensemble_prob = EnsembleProblem(prob, output_func = (sol, ctx) -> (sol.u[end], false))
         sol = solve(ensemble_prob, dt = 1 / 10, trajectories = 40_000)
         @test mean(sol) ≈ expected_mean rtol = 0.1
         @test var(sol) ≈ expected_variance atol = 0.1
@@ -60,7 +60,7 @@
 
         ensemble_probW = EnsembleProblem(
             prob,
-            output_func = (sol, i) -> (sol.W.W[end], false)
+            output_func = (sol, ctx) -> (sol.W.W[end], false)
         )
 
         solW_at_1 = solve(ensemble_probW, EM(), dt = 1 / 10, trajectories = 40_000)
@@ -86,7 +86,7 @@
         @test varW ≈ expected_variance rtol = 0.1
 
         prob = NoiseProblem(W, tspan)
-        ensemble_prob = EnsembleProblem(prob, output_func = (sol, i) -> (sol.u[end], false))
+        ensemble_prob = EnsembleProblem(prob, output_func = (sol, ctx) -> (sol.u[end], false))
         sol = solve(ensemble_prob, dt = 1 / 10, trajectories = 40_000)
         @test mean(sol) ≈ expected_mean rtol = 0.1
         @test var(sol) ≈ expected_variance atol = 0.1
@@ -95,7 +95,7 @@
 
         ensemble_probW = EnsembleProblem(
             prob,
-            output_func = (sol, i) -> (sol.W.W[end], false)
+            output_func = (sol, ctx) -> (sol.W.W[end], false)
         )
 
         solW_at_1 = solve(ensemble_probW, EM(), dt = 1 / 10, trajectories = 40_000)
@@ -117,7 +117,7 @@
         @test varW ≈ expected_variance atol = 0.1
 
         prob = NoiseProblem(W, tspan)
-        ensemble_prob = EnsembleProblem(prob, output_func = (sol, i) -> (sol.u[end], false))
+        ensemble_prob = EnsembleProblem(prob, output_func = (sol, ctx) -> (sol.u[end], false))
         sol = solve(ensemble_prob, dt = 1 / 10, trajectories = 40_000)
         @test mean(sol) ≈ expected_mean rtol = 0.1
         @test var(sol) ≈ expected_variance atol = 0.1
@@ -126,7 +126,7 @@
 
         ensemble_probW = EnsembleProblem(
             prob,
-            output_func = (sol, i) -> (sol.W.W[end], false)
+            output_func = (sol, ctx) -> (sol.W.W[end], false)
         )
 
         solW_at_1 = solve(ensemble_probW, EM(), dt = 1 / 10, trajectories = 40_000)
@@ -152,7 +152,7 @@
         @test varW ≈ expected_variance atol = 0.1
 
         prob = NoiseProblem(W, tspan)
-        ensemble_prob = EnsembleProblem(prob, output_func = (sol, i) -> (sol.u[end], false))
+        ensemble_prob = EnsembleProblem(prob, output_func = (sol, ctx) -> (sol.u[end], false))
         sol = solve(ensemble_prob, dt = 1 / 10, trajectories = 40_000)
         @test mean(sol) ≈ expected_mean rtol = 0.1
         @test var(sol) ≈ expected_variance atol = 0.1
@@ -161,7 +161,7 @@
 
         ensemble_probW = EnsembleProblem(
             prob,
-            output_func = (sol, i) -> (sol.W.W[end], false)
+            output_func = (sol, ctx) -> (sol.W.W[end], false)
         )
 
         solW_at_1 = solve(ensemble_probW, EM(), dt = 1 / 10, trajectories = 40_000)
@@ -184,7 +184,7 @@
         @test varW ≈ expected_variance atol = 0.1
 
         prob = NoiseProblem(W, tspan)
-        ensemble_prob = EnsembleProblem(prob, output_func = (sol, i) -> (sol.u[end], false))
+        ensemble_prob = EnsembleProblem(prob, output_func = (sol, ctx) -> (sol.u[end], false))
         sol = solve(ensemble_prob, dt = 1 / 10, trajectories = 40_000)
         @test mean(sol) ≈ expected_mean rtol = 0.1
         @test var(sol) ≈ expected_variance atol = 0.1
@@ -193,7 +193,7 @@
 
         ensemble_probW = EnsembleProblem(
             prob,
-            output_func = (sol, i) -> (sol.W.W[end], false)
+            output_func = (sol, ctx) -> (sol.W.W[end], false)
         )
 
         solW_at_1 = solve(ensemble_probW, EM(), dt = 1 / 10, trajectories = 40_000)
@@ -216,7 +216,7 @@
         prob = NoiseProblem(W, tspan)
         ensemble_prob = EnsembleProblem(
             prob,
-            output_func = (sol, i) -> (first(sol(t)), false)
+            output_func = (sol, ctx) -> (first(sol(t)), false)
         )
         sol = solve(ensemble_prob, dt = 1 / 10, trajectories = 40_000)
 
@@ -227,7 +227,7 @@
 
         ensemble_probW = EnsembleProblem(
             prob,
-            output_func = (sol, i) -> (first(sol.W(t)), false)
+            output_func = (sol, ctx) -> (first(sol.W(t)), false)
         )
         solW_at_1 = solve(ensemble_probW, EM(), dt = 1 / 10, trajectories = 40_000)
 


### PR DESCRIPTION
## Summary

This PR updates DiffEqNoiseProcess.jl for compatibility with the OrdinaryDiffEq v7 / SciMLBase v3 ecosystem, following the breaking changes in SciML/OrdinaryDiffEq.jl#3562 and SciML/OrdinaryDiffEq.jl#3565.

### Changes

- **Project.toml**: Add `StochasticDiffEq = "6, 7"` compat entry — StochasticDiffEq v7 was released alongside OrdinaryDiffEq v7 but was missing a compat bound (it was only listed in `[extras]`/`[targets]` with no compat constraint).

- **Test files**: Migrate `EnsembleProblem` callback signatures for SciMLBase v3:
  - `output_func = (sol, i) -> ...` → `output_func = (sol, ctx) -> ...`
  - `prob_func(prob, i, repeat)` → `prob_func(prob, ctx)`
  
  SciMLBase v3 replaced the two positional index arguments with a single `EnsembleContext` object (`ctx`) containing `ctx.sim_id`, `ctx.repeat`, `ctx.rng`, etc. This affects: `test/reinit_test.jl`, `test/bridge_test.jl`, `test/pcn_test.jl`, `test/geometric_bm.jl`, `test/compoundpoisson.jl`, `test/correlated.jl`, `test/ornstein.jl`.

### Pre-existing test failure

`test/noise_wrapper.jl` has a pre-existing failure in "Interpolation with small eps jumps" at `rtol=1.0e-10` precision — this failure exists on `master` before these changes and is unrelated to this PR.

### References
- SciML/OrdinaryDiffEq.jl#3562
- SciML/OrdinaryDiffEq.jl#3565
- [OrdinaryDiffEq.jl NEWS.md](https://github.com/SciML/OrdinaryDiffEq.jl/blob/master/NEWS.md)