### PR TITLE
Centralize CI on SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,14 +5,11 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"
       - "/docs"
-      - "/test"
+      - "/test/qa"
     schedule:
       interval: "daily"
     groups:

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -13,20 +13,12 @@ on:
 jobs:
   test:
     if: false  # Disabled: waiting on upstream dependency updates. See issue #245 for details.
-    runs-on: ubuntu-latest
+    name: "Downgrade"
     strategy:
       matrix:
-        downgrade_mode: ['alldeps']
         julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "${{ matrix.julia-version }}"
+      skip: "Pkg,TOML"
+    secrets: "inherit"

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -8,10 +8,8 @@ on:
 jobs:
   test:
     name: ${{ matrix.package.repo }}/${{ matrix.package.group }}/${{ matrix.julia-version }}
-    runs-on: ${{ matrix.os }}
-    env:
-      GROUP: ${{ matrix.package.group }}
     strategy:
+      fail-fast: false
       matrix:
         julia-version: [1]
         os: [ubuntu-latest]
@@ -22,38 +20,11 @@ jobs:
           - {user: SciML, repo: SciMLSensitivity.jl, group: SDE1}
           - {user: SciML, repo: SciMLSensitivity.jl, group: SDE2}
           - {user: SciML, repo: SciMLSensitivity.jl, group: SDE3}
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-          arch: x64
-      - uses: julia-actions/julia-buildpkg@latest
-      - name: Clone Downstream
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ matrix.package.user }}/${{ matrix.package.repo }}
-          path: downstream
-      - name: Load this and run the downstream tests
-        shell: julia --color=yes --project=downstream {0}
-        run: |
-          using Pkg
-          try
-            # force it to use this PR's version of the package
-            Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
-            Pkg.update()
-            Pkg.test(coverage=true)  # resolver may fail with test time deps
-          catch err
-            err isa Pkg.Resolve.ResolverError || rethrow()
-            # If we can't resolve that means this is incompatible by SemVer and this is fine
-            # It means we marked this as a breaking change, so we don't need to worry about
-            # Mistakenly introducing a breaking change, as we have intentionally made one
-            @info "Not compatible with this release. No problem." exception=err
-            exit(0)  # Exit immediately, as a success
-          end
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v6
-        with:
-          files: lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+    uses: "SciML/.github/.github/workflows/downstream.yml@v1"
+    with:
+      julia-version: "${{ matrix.julia-version }}"
+      os: "${{ matrix.os }}"
+      owner: "${{ matrix.package.user }}"
+      repo: "${{ matrix.package.repo }}"
+      group: "${{ matrix.package.group }}"
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,6 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    name: "Runic"
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/QA.yml
+++ b/.github/workflows/QA.yml
@@ -19,28 +19,13 @@ concurrency:
 jobs:
   qa:
     name: "QA"
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         version:
           - "1"
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.version }}
-      - uses: actions/cache@v5
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          coverage: false
-        env:
-          GROUP: QA
+    uses: "SciML/.github/.github/workflows/tests.yml@v1"
+    with:
+      julia-version: "${{ matrix.version }}"
+      group: "QA"
+      coverage: false
+    secrets: "inherit"

--- a/.github/workflows/SelfHosted.yml
+++ b/.github/workflows/SelfHosted.yml
@@ -19,21 +19,8 @@ concurrency:
 jobs:
   bridge-tests:
     name: "Bridge Tests"
-    runs-on: [self-hosted, ubuntu-latest]
-    timeout-minutes: 120
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: "1"
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        env:
-          GROUP: "Bridge"
-          JULIA_NUM_THREADS: auto
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v6
-        with:
-          files: lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: false
+    uses: "SciML/.github/.github/workflows/tests.yml@v1"
+    with:
+      group: "Bridge"
+      self-hosted: true
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,6 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.1 
+    name: "Spell Check with Typos"
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,5 +1,7 @@
 [default.extend-words]
 currate = "currate"
+# `indx` is a public keyword-argument name in src/pCN.jl, not a typo
+indx = "indx"
 # Additional SciML terms
 setp = "setp"
 getp = "getp"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Converts the remaining inline CI jobs to the centralized `SciML/.github` reusable workflows pinned at `@v1`, and adds `secrets: "inherit"` to every caller. Behavior and matrices are preserved.

## Converted (inline -> central caller)
- **QA.yml** — inline `julia-runtest` (`GROUP=QA`, coverage off) -> `tests.yml@v1` with `group: QA`, `coverage: false`, version matrix `["1"]`.
- **SelfHosted.yml** — inline self-hosted bridge tests (`GROUP=Bridge`) -> `tests.yml@v1` with `group: Bridge`, `self-hosted: true`.
- **FormatCheck.yml** — inline `fredrikekre/runic-action` -> `runic.yml@v1`.
- **SpellCheck.yml** — inline `crate-ci/typos` -> `spellcheck.yml@v1`.
- **Downgrade.yml** — inline downgrade (was `if: false`) -> `downgrade.yml@v1` (`julia-version: 1.10`, `skip: Pkg,TOML`); kept `if: false` (disabled per issue #245).
- **Downstream.yml** (IntegrationTest) — inline matrix -> matrix of `downstream.yml@v1` callers, preserving the exact package+group list (StochasticDiffEq.jl Interface/Interface2/Interface3, SciMLSensitivity.jl SDE1/SDE2/SDE3).

## Already central (left as-is)
- **Tests.yml** — already `tests.yml@v1` (`secrets: inherit`, versions `["1","lts","pre"]`).
- **Documentation.yml** — already `documentation.yml@v1`.
- **TagBot.yml** — unchanged.

## Other changes
- **dependabot.yml** — removed the `crate-ci/typos` version-ignore; pointed the `julia` ecosystem at dirs that actually contain a `Project.toml` (`/`, `/docs`, `/test/qa`; dropped the non-manifest `/test`). `github-actions` block kept (weekly, `/`).
- **.typos.toml** — allowlisted `indx`, which is a public keyword-argument name in `src/pCN.jl` (80 occurrences). Not a prose typo; renaming would break the API.

## Notes / caveats
- **Runic**: no formatting changes were needed (repo was already Runic-clean).
- **Typos fixed**: 0 prose fixes; the only finding (`indx`) is an identifier and was allowlisted.
- **SelfHosted**: the original job set `JULIA_NUM_THREADS: auto` and `timeout-minutes: 120`; these are not exposed as `tests.yml@v1` inputs, so they are dropped. Coverage in the original used `fail_ci_if_error: false`; the central caller manages coverage itself.
- **QA**: the central `tests.yml@v1` runs `julia-buildpkg` before tests, which the old inline QA job did not; harmless (QA uses a separate `test/qa` env).
- **Check names will change** (e.g. jobs now run as reusable-workflow calls). Branch-protection required-status-check names will need updating after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)