### PR TITLE
Fix NoiseProblem solve overshooting tspan[2]

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -44,10 +44,28 @@ function DiffEqBase.__solve(
     setup_next_step!(W, nothing, nothing)
     tType = typeof(W.curt)
     while W.curt < prob.tspan[2]
-        if tType <: AbstractFloat && abs(W.curt + dt - prob.tspan[2]) < 100 * eps(dt) # Correct the end due to floating point error
-            dt = prob.tspan[2] - W.curt
+        # Tolerance scaled by the magnitude of the time values rather than by `dt`:
+        # the floating point drift accumulated over many steps is on the order of
+        # `eps(tspan[2])`, which can be far larger than `eps(dt)` when `dt` is small.
+        # The previous `100 * eps(dt)` tolerance was therefore essentially never hit,
+        # so the solve took a full extra step and stopped past `tspan[2]`.
+        endtol = tType <: AbstractFloat ?
+            100 * eps(tType(max(abs(prob.tspan[2]), abs(W.curt)))) : zero(W.curt)
+        if tType <: AbstractFloat && abs(prob.tspan[2] - (W.curt + W.dt)) <= endtol
+            # The prepared step lands on `tspan[2]` up to floating point drift. Take it as
+            # usual but snap the recorded endpoint exactly onto `tspan[2]` so the solution
+            # neither overshoots nor stops just short of the requested final time.
             accept_step!(W, dt, nothing, nothing)
             W.curt = prob.tspan[2]
+            W.save_everystep && (W.t[end] = prob.tspan[2])
+        elseif tType <: AbstractFloat && W.curt + W.dt > prob.tspan[2] + endtol
+            # The prepared step would overshoot `tspan[2]` by more than rounding. Recompute
+            # it at exactly the remaining width so the solution ends on `tspan[2]`.
+            dtcorrect = prob.tspan[2] - W.curt
+            calculate_step!(W, dtcorrect, nothing, nothing)
+            accept_step!(W, dtcorrect, nothing, nothing)
+            W.curt = prob.tspan[2]
+            W.save_everystep && (W.t[end] = prob.tspan[2])
         else
             accept_step!(W, dt, nothing, nothing)
         end

--- a/test/savestep_test.jl
+++ b/test/savestep_test.jl
@@ -22,3 +22,36 @@
         @test sol_save.curW == sol_nosave.curW
     end
 end
+
+@testset "Noise solution lands exactly on the endpoint" begin
+    # A NoiseProblem solve must stop exactly on tspan[2] and never step past it.
+    # Floating point drift accumulated over many steps is ~eps(tspan[2]), which can be
+    # far larger than eps(dt) for small dt, so the end correction must be scaled by the
+    # magnitude of the time values. Otherwise the solve overshoots the requested endpoint.
+    using DiffEqNoiseProcess, DiffEqBase, Test, Random
+    processes = [
+        OrnsteinUhlenbeckProcess(1.0, 1.0, 0.3, 0.0, 0.0, nothing),
+        WienerProcess(0.0, 0.0, nothing),
+        CorrelatedWienerProcess([1.0 0.0; 0.0 1.0], 0.0, [0.0; 0.0], nothing),
+        GeometricBrownianMotionProcess(1.0, 1.0, 0.0, 0.0, nothing),
+    ]
+    # tspan/dt combinations chosen so that dt does not divide the span cleanly and the
+    # accumulated drift is large compared to eps(dt) (the previously buggy regime).
+    cases = [
+        ((0.0, 1.0), 1.0e-4),
+        ((0.0, 1.0), 0.1),
+        ((0.0, 2.3), 0.01),
+        ((0.0, 1.0), 1 / 3),
+    ]
+    @testset "process = $(proc.dist)" for proc in processes
+        @testset "tspan = $tspan, dt = $dt" for (tspan, dt) in cases
+            cproc = deepcopy(proc)
+            prob = NoiseProblem(cproc, tspan; seed = 1234)
+            sol = solve(prob; dt = dt)
+            @test sol.t[end] == tspan[2]
+            @test sol.curt == tspan[2]
+            @test sol.t[end] <= tspan[2]
+            @test issorted(sol.t)
+        end
+    end
+end


### PR DESCRIPTION
## What this fixes

`solve(::NoiseProblem; dt)` could stop **past** `tspan[2]`. The end-of-span
correction in `DiffEqBase.__solve` used `abs(W.curt + dt - prob.tspan[2]) < 100 * eps(dt)`.
For small `dt`, `100 * eps(dt)` (e.g. `~1.6e-18` for `dt = 1e-4`) is far smaller
than the floating point drift accumulated over thousands of `W.curt += W.dt`
steps (`~eps(tspan[2])`, e.g. `~9e-14`). The correction branch was therefore
essentially never taken, and the loop took one full extra step, ending past the
requested final time.

Examples on master (`WienerProcess`/`OrnsteinUhlenbeck`/etc.):

| tspan | dt | `sol.t[end]` (master) | overshoot |
|-------|----|-----------------------|-----------|
| (0,1)   | 1e-4 | 1.0000999999999063 | ~1e-4 |
| (0,2.3) | 0.01 | 2.3099999999999947 | ~1e-2 |

For a `BrownianBridge` whose `dt` does not divide the span (e.g. `dt = 0.03`),
the overshoot also moved the pinned endpoint off `tspan[2]` entirely.

## The fix

Scale the end tolerance by the magnitude of the time values instead of `dt`, and:

- if the prepared step already lands on `tspan[2]` up to rounding, take it
  normally and snap the recorded endpoint exactly onto `tspan[2]` (no extra
  point) — this preserves the existing clean-`dt` behaviour and the
  `BrownianBridge` endpoint pinning that `bridge_test` depends on;
- if the prepared step would overshoot by more than rounding, recompute it at
  exactly the remaining width via `calculate_step!` so the solve ends on
  `tspan[2]`.

## Verification (run locally, Julia 1.10.11, isolated depot)

- New regression test `test/savestep_test.jl` "Noise solution lands exactly on
  the endpoint": **fails 28/64 on unpatched master**, **passes 68/68 with this
  patch** (`savestep | 68 68`).
- Full `GROUP=Core1` `Pkg.test()` with this patch shows **no new failures**:
  `Correlated Wiener Process | 5 5`, `NoiseWrapper | 5 5`, etc. all pass; the
  only remaining failure is the pre-existing `noise_wrapper.jl` "Interpolation
  with small eps jumps" testset (see below), which this PR does not touch.
- `BrownianBridge` endpoint pinning for the tested `dt = 0.1` is unchanged
  (ensemble endpoint mean `1.0`, var `~2e-32`).
- `Runic` clean on both changed files.

## Note: the pre-existing `save_end` test failure is upstream, not here

While locating this bug I confirmed the failing `noise_wrapper.jl` testset
"Interpolation with small eps jumps" (the `save_end = false` SDE assertions) is
**not** a DiffEqNoiseProcess bug. The noise process `W` is byte-identical for
`save_end = true`/`false`. The failure is a behaviour change from the
StochasticDiffEq 6→7 centralization onto `OrdinaryDiffEqCore`'s unified save
loop: `OrdinaryDiffEqCore._savevalues!` gates the per-step `save_everystep`
save with `(save_end || integrator.t !== tspan[2])`, so a genuine
`save_everystep = true` step landing exactly on `tspan[2]` is now dropped when
`save_end = false`. StochasticDiffEq 6.x's own `savevalues!` had no such gate.

Verified: the testset **passes under StochasticDiffEq 6.74.1** and **passes
again under 7.0 if that clause is removed in OrdinaryDiffEqCore**. That is a
SciML-wide semantics decision (it affects pure-ODE `save_end` too), so it is
left for maintainers rather than changed here, and this PR intentionally does
not modify that test.

> Ignore until reviewed by @ChrisRackauckas.
