### PR TITLE
Re-enable Downgrade job (strict, intentionally RED)

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -11,8 +11,8 @@ on:
     paths-ignore:
       - 'docs/**'
 jobs:
+  # Runs strict (allow_reresolve=false); expected RED until ForwardDiff/LogExpFunctions strict wall (likely) resolves.
   test:
-    if: false  # Disabled: waiting on upstream dependency updates. See issue #245 for details.
     name: "Downgrade"
     strategy:
       matrix:


### PR DESCRIPTION
Removes `if: false` from `.github/workflows/Downgrade.yml` so the centralized Downgrade workflow actually runs instead of being skipped.

downgrade re-enabled strict; intentionally RED (natural failure, not disabled) pending ForwardDiff/LogExpFunctions strict wall (likely); auto-greens when that resolves.

Strict resolution is preserved: `allow_reresolve` defaults to `false` in `SciML/.github/.github/workflows/downgrade.yml@v1` and is not overridden here. Floors are unchanged and julia stays at "1.10".

Please ignore this PR until reviewed by @ChrisRackauckas.