### PR TITLE
Fix master test failures: noise_wrapper save_end semantics (#276), #278 fallout, and CI silently running zero tests

### DIFF
--- a/src/correlated_noisefunc.jl
+++ b/src/correlated_noisefunc.jl
@@ -38,8 +38,11 @@ end
 function construct_correlated_noisefunc!(Γ)
     γ = svd(Γ)
     A = γ.U * Diagonal(sqrt.(γ.S))
-    b = Vector{eltype(Γ)}(undef, size(Γ, 1))
+    # The scratch vector must live inside the call: the closure is shared across
+    # `copy`s of the process, so a captured buffer is raced on by ensemble
+    # trajectories running on different threads.
     dist = function (rand_vec, W, dt, u, p, t, rng)
+        b = Vector{eltype(rand_vec)}(undef, length(rand_vec))
         wiener_randn!(rng, b)
         b .*= sqrt.(abs(dt))
         return mul!(rand_vec, A, b)

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -21,6 +21,16 @@ prob = NoiseProblem(W, (0.0, 1.0))
 sol = solve(prob; dt = 0.01)
 ```
 """
+# After the endpoint is snapped onto `tspan[2]`, the next step prepared inside
+# `accept_step!` still corresponds to the unsnapped `curt`. For function-evaluated
+# noises the prepared step is a pure function of `curt`, so recompute it at the
+# snapped time to keep `dW == W(curt + dt) - curW` exact. Stateful processes can't
+# be re-prepared (RSwM stack pops, grid domain guards), and for them the prepared
+# step is random so the sub-eps time label drift is unobservable.
+resync_prepared_step!(W::Union{NoiseFunction, NoiseTransport}) =
+    calculate_step!(W, W.dt, nothing, nothing)
+resync_prepared_step!(W) = nothing
+
 function DiffEqBase.__solve(
         prob::AbstractNoiseProblem,
         args::Union{Nothing, SciMLBase.AbstractDEAlgorithm}...; dt = 0.0,
@@ -61,6 +71,7 @@ function DiffEqBase.__solve(
             # types like NoiseFunction and NoiseGrid have no `save_everystep` field.
             hasfield(typeof(W), :save_everystep) && W.save_everystep &&
                 (W.t[end] = prob.tspan[2])
+            resync_prepared_step!(W)
         elseif tType <: AbstractFloat && W.curt + W.dt > prob.tspan[2] + endtol
             # The prepared step would overshoot `tspan[2]` by more than rounding. Recompute
             # it at exactly the remaining width so the solution ends on `tspan[2]`.
@@ -70,6 +81,7 @@ function DiffEqBase.__solve(
             W.curt = prob.tspan[2]
             hasfield(typeof(W), :save_everystep) && W.save_everystep &&
                 (W.t[end] = prob.tspan[2])
+            resync_prepared_step!(W)
         else
             accept_step!(W, dt, nothing, nothing)
         end

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -57,7 +57,10 @@ function DiffEqBase.__solve(
             # neither overshoots nor stops just short of the requested final time.
             accept_step!(W, dt, nothing, nothing)
             W.curt = prob.tspan[2]
-            W.save_everystep && (W.t[end] = prob.tspan[2])
+            # Only NoiseProcess/SimpleNoiseProcess record a `t` timeseries to snap;
+            # types like NoiseFunction and NoiseGrid have no `save_everystep` field.
+            hasfield(typeof(W), :save_everystep) && W.save_everystep &&
+                (W.t[end] = prob.tspan[2])
         elseif tType <: AbstractFloat && W.curt + W.dt > prob.tspan[2] + endtol
             # The prepared step would overshoot `tspan[2]` by more than rounding. Recompute
             # it at exactly the remaining width so the solution ends on `tspan[2]`.
@@ -65,7 +68,8 @@ function DiffEqBase.__solve(
             calculate_step!(W, dtcorrect, nothing, nothing)
             accept_step!(W, dtcorrect, nothing, nothing)
             W.curt = prob.tspan[2]
-            W.save_everystep && (W.t[end] = prob.tspan[2])
+            hasfield(typeof(W), :save_everystep) && W.save_everystep &&
+                (W.t[end] = prob.tspan[2])
         else
             accept_step!(W, dt, nothing, nothing)
         end

--- a/test/bridge_test.jl
+++ b/test/bridge_test.jl
@@ -1,10 +1,45 @@
+# Memory discipline for this file: it draws 4 x 100k ensemble trajectories and
+# 9 x 500k bridge trajectories. Retaining full solution objects peaks at ~21GB
+# resident and OOMs the 7GB hosted CI runners, so the ensembles keep only the
+# value arrays (timestep_mean/timestep_meanvar need `el.u[i]`) and the Ou-Bridge
+# testsets accumulate streaming sums instead of solution collections — only the
+# elementwise mean/std are asserted.
+keep_u = (sol, ctx) -> ((u = sol.u,), false)
+
+mutable struct RunningStats
+    n::Int
+    sum::Vector{Float64}
+    sumsq::Vector{Float64}
+    RunningStats() = new(0, Float64[], Float64[])
+end
+function push_stats!(rs::RunningStats, u)
+    if rs.n == 0
+        resize!(rs.sum, length(u))
+        fill!(rs.sum, 0.0)
+        resize!(rs.sumsq, length(u))
+        fill!(rs.sumsq, 0.0)
+    end
+    rs.n += 1
+    for i in eachindex(u)
+        v = first(u[i])
+        rs.sum[i] += v
+        rs.sumsq[i] += abs2(v)
+    end
+    return rs
+end
+stats_mean(rs::RunningStats) = rs.sum ./ rs.n
+function stats_std(rs::RunningStats)
+    m = stats_mean(rs)
+    return sqrt.(max.(rs.sumsq ./ rs.n .- abs2.(m), 0.0) .* (rs.n / (rs.n - 1)))
+end
+
 @testset "Brownian Bridge" begin
     using DiffEqNoiseProcess, DiffEqBase, Test, Random, DiffEqBase.EnsembleAnalysis
 
     Random.seed!(100)
     W = BrownianBridge(0.0, 1.0, 0.0, 1.0, 0.0, 0.0)
     prob = NoiseProblem(W, (0.0, 1.0))
-    ensemble_prob = EnsembleProblem(prob)
+    ensemble_prob = EnsembleProblem(prob, output_func = keep_u)
     @time sol = solve(ensemble_prob, dt = 0.1, trajectories = 100000)
 
     # Spot check the mean and the variance
@@ -28,7 +63,7 @@
 
     W = GeometricBrownianBridge(μ, σ, t0, tend, GB0, GBend)
     prob = NoiseProblem(W, (t0, tend))
-    ensemble_prob = EnsembleProblem(prob)
+    ensemble_prob = EnsembleProblem(prob, output_func = keep_u)
     @time sol = solve(ensemble_prob, dt = 1.0, trajectories = 100000)
     ts = t0:1.0:tend
     for i in 2:10
@@ -47,7 +82,7 @@
     rate(u, p, t) = r
     W = CompoundPoissonBridge(rate, 0.0, 1.0, 0.0, 1.0)
     prob = NoiseProblem(W, (0.0, 1.0))
-    ensemble_prob = EnsembleProblem(prob)
+    ensemble_prob = EnsembleProblem(prob, output_func = keep_u)
     @time sol = solve(ensemble_prob, dt = 0.1, trajectories = 100000)
 
     # Spot check the mean and the variance
@@ -72,7 +107,7 @@
         Wtmp = VirtualBrownianTree(0.0, 0.0; Wend = 1.0, tree_depth = 3)
         remake(prob, noise = Wtmp)
     end
-    ensemble_prob = EnsembleProblem(prob, prob_func = prob_func)
+    ensemble_prob = EnsembleProblem(prob, prob_func = prob_func, output_func = keep_u)
     @time sol = solve(ensemble_prob, dt = 0.125, trajectories = 100000)
 
     # Spot check the mean and the variance
@@ -91,94 +126,79 @@ end
 @testset "Scalar Ou-Bridge" begin
     using DiffEqNoiseProcess,
         DiffEqBase, Test, Random, DiffEqBase.EnsembleAnalysis, StatsBase, Statistics
-    sols_forward = []
+    stats_forward = RunningStats()
     dt = 0.125
     t_max = 20.0
-    n = Int(t_max / dt + 2)
     st = []
     Random.seed!(1234)
     for i in 1:500_000
         local ou = OrnsteinUhlenbeckProcess(1.5, 0.25, 0.2, 0.0, 0.0)
         local prob = NoiseProblem(ou, (0.0, t_max))
         local s = solve(prob; dt = dt)
-        push!(sols_forward, s.u)
+        push_stats!(stats_forward, s.u)
         if i == 1
             st = s.t
         end
     end
 
-    st2 = []
-    sols_interpolated = []
+    stats_interpolated = RunningStats()
     Random.seed!(1234)
     ou = OrnsteinUhlenbeckProcess(1.5, 0.25, 0.2, 0.0, 0.0)
     for i in 1:500_000
         local prob = NoiseProblem(ou, (0.0, t_max))
         local s2 = solve(prob; dt = t_max)
         s2.(st)
-        push!(sols_interpolated, s2.u)
-        if i == 1
-            st2 = s2.t
-        end
+        push_stats!(stats_interpolated, s2.u)
     end
 
     Random.seed!(1234)
     ou = OrnsteinUhlenbeckProcess(1.5, 0.25, 0.2, 0.0, 0.0)
     prob = NoiseProblem(ou, (0.0, t_max))
-    sols_solver = []
-    st = []
+    stats_solver = RunningStats()
     for i in 1:500_000
         local s = solve(prob; dt = t_max)
         ou_bridge = OrnsteinUhlenbeckBridge(1.5, 0.25, 0.2, 0.0, t_max, 0.0, s.u[end])
         s = solve(NoiseProblem(ou_bridge, (0.0, t_max)); dt = 0.125)
-        push!(sols_solver, s.u)
-        if i == 1
-            st = s.t
-        end
+        push_stats!(stats_solver, s.u)
     end
 
-    @test all(isapprox.(mean(sols_forward), mean(sols_interpolated); atol = 1.0e-3))
-    @test all(isapprox.(mean(sols_forward), mean(sols_solver); atol = 1.0e-3))
+    @test all(isapprox.(stats_mean(stats_forward), stats_mean(stats_interpolated); atol = 1.0e-3))
+    @test all(isapprox.(stats_mean(stats_forward), stats_mean(stats_solver); atol = 1.0e-3))
 
-    @test all(isapprox.(std(sols_forward), std(sols_interpolated); atol = 1.0e-3))
-    @test all(isapprox.(std(sols_forward), std(sols_solver); atol = 1.0e-3))
+    @test all(isapprox.(stats_std(stats_forward), stats_std(stats_interpolated); atol = 1.0e-3))
+    @test all(isapprox.(stats_std(stats_forward), stats_std(stats_solver); atol = 1.0e-3))
 end
 
 @testset "Vector Ou-Bridge" begin
-    sols_forward = []
+    stats_forward = RunningStats()
     dt = 0.125
     t_max = 20.0
-    n = Int(t_max / dt + 2)
     st = []
     Random.seed!(1234)
     ou = OrnsteinUhlenbeckProcess([1.5], [0.25], [0.2], 0.0, [0.0])
     for i in 1:500_000
         local prob = NoiseProblem(ou, (0.0, t_max))
         local s = solve(prob; dt = dt)
-        push!(sols_forward, s.u)
+        push_stats!(stats_forward, s.u)
         if i == 1
             st = s.t
         end
     end
 
-    st2 = []
-    sols_interpolated = []
+    stats_interpolated = RunningStats()
     Random.seed!(1234)
     ou = OrnsteinUhlenbeckProcess([1.5], [0.25], [0.2], 0.0, [0.0])
     for i in 1:500_000
         local prob = NoiseProblem(ou, (0.0, t_max))
         local s2 = solve(prob; dt = t_max)
         s2.(st)
-        push!(sols_interpolated, s2.u)
-        if i == 1
-            st2 = s2.t
-        end
+        push_stats!(stats_interpolated, s2.u)
     end
 
     Random.seed!(1234)
     ou = OrnsteinUhlenbeckProcess([1.5], [0.25], [0.2], 0.0, [0.0])
     prob = NoiseProblem(ou, (0.0, t_max))
-    sols_solver = []
-    st = []
+    stats_solver = RunningStats()
     for i in 1:500_000
         local s = solve(prob; dt = t_max)
         local ou_bridge = OrnsteinUhlenbeckBridge(
@@ -190,66 +210,47 @@ end
             [0.0],
             s.u[end]
         )
-        local s = solve(NoiseProblem(ou_bridge, (0.0, t_max)); dt = 0.125)
-        push!(sols_solver, s.u)
-        if i == 1
-            st = s.t
-        end
+        local s2 = solve(NoiseProblem(ou_bridge, (0.0, t_max)); dt = 0.125)
+        push_stats!(stats_solver, s2.u)
     end
 
-    sols_forward = map(sols_forward) do x
-        [y[1] for y in x]
-    end
-    sols_interpolated = map(sols_interpolated) do x
-        [y[1] for y in x]
-    end
-    sols_solver = map(sols_solver) do x
-        [y[1] for y in x]
-    end
+    @test all(isapprox.(stats_mean(stats_forward), stats_mean(stats_interpolated); atol = 1.0e-3))
+    @test all(isapprox.(stats_mean(stats_forward), stats_mean(stats_solver); atol = 1.0e-3))
 
-    @test all(isapprox.(mean(sols_forward), mean(sols_interpolated); atol = 1.0e-3))
-    @test all(isapprox.(mean(sols_forward), mean(sols_solver); atol = 1.0e-3))
-
-    @test all(isapprox.(std(sols_forward), std(sols_interpolated); atol = 1.0e-3))
-    @test all(isapprox.(std(sols_forward), std(sols_solver); atol = 1.0e-3))
+    @test all(isapprox.(stats_std(stats_forward), stats_std(stats_interpolated); atol = 1.0e-3))
+    @test all(isapprox.(stats_std(stats_forward), stats_std(stats_solver); atol = 1.0e-3))
 end
 
 @testset "Inplace OU-Bridge" begin
-    sols_forward = []
+    stats_forward = RunningStats()
     dt = 0.125
     t_max = 20.0
-    n = Int(t_max / dt + 2)
     st = []
     Random.seed!(1234)
     ou = OrnsteinUhlenbeckProcess!([1.5], [0.25], [0.2], 0.0, [0.0])
     for i in 1:500_000
         local prob = NoiseProblem(ou, (0.0, t_max))
         local s = solve(prob; dt = dt)
-        push!(sols_forward, s.u)
+        push_stats!(stats_forward, s.u)
         if i == 1
             st = s.t
         end
     end
 
-    st2 = []
-    sols_interpolated = []
+    stats_interpolated = RunningStats()
     Random.seed!(1234)
     ou = OrnsteinUhlenbeckProcess!([1.5], [0.25], [0.2], 0.0, [0.0])
     for i in 1:500_000
         local prob = NoiseProblem(ou, (0.0, t_max))
         local s2 = solve(prob; dt = t_max)
         s2.(st)
-        push!(sols_interpolated, s2.u)
-        if i == 1
-            st2 = s2.t
-        end
+        push_stats!(stats_interpolated, s2.u)
     end
 
     Random.seed!(1234)
     ou = OrnsteinUhlenbeckProcess!([1.5], [0.25], [0.2], 0.0, [0.0])
     prob = NoiseProblem(ou, (0.0, t_max))
-    sols_solver = []
-    st = []
+    stats_solver = RunningStats()
     for i in 1:500_000
         local s = solve(prob; dt = t_max)
         local ou_bridge = OrnsteinUhlenbeckBridge!(
@@ -261,26 +262,13 @@ end
             [0.0],
             s.u[end]
         )
-        local s = solve(NoiseProblem(ou_bridge, (0.0, t_max)); dt = 0.125)
-        push!(sols_solver, s.u)
-        if i == 1
-            st = s.t
-        end
+        local s2 = solve(NoiseProblem(ou_bridge, (0.0, t_max)); dt = 0.125)
+        push_stats!(stats_solver, s2.u)
     end
 
-    sols_forward = map(sols_forward) do x
-        [y[1] for y in x]
-    end
-    sols_interpolated = map(sols_interpolated) do x
-        [y[1] for y in x]
-    end
-    sols_solver = map(sols_solver) do x
-        [y[1] for y in x]
-    end
+    @test all(isapprox.(stats_mean(stats_forward), stats_mean(stats_interpolated); atol = 1.0e-3))
+    @test all(isapprox.(stats_mean(stats_forward), stats_mean(stats_solver); atol = 1.0e-3))
 
-    @test all(isapprox.(mean(sols_forward), mean(sols_interpolated); atol = 1.0e-3))
-    @test all(isapprox.(mean(sols_forward), mean(sols_solver); atol = 1.0e-3))
-
-    @test all(isapprox.(std(sols_forward), std(sols_interpolated); atol = 1.0e-3))
-    @test all(isapprox.(std(sols_forward), std(sols_solver); atol = 1.0e-3))
+    @test all(isapprox.(stats_std(stats_forward), stats_std(stats_interpolated); atol = 1.0e-3))
+    @test all(isapprox.(stats_std(stats_forward), stats_std(stats_solver); atol = 1.0e-3))
 end

--- a/test/extraction_test.jl
+++ b/test/extraction_test.jl
@@ -47,7 +47,9 @@
 
     W4 = NoiseWrapper(_sol, reverse = true)
     for i in 1:1:length(tarray)
-        t = tarray[end - i + 1]
+        # Query the actually saved times: the accumulated tarray drifts past
+        # tspan[2] while the solve snaps its final time onto tspan[2] exactly.
+        t = _sol.t[end - i + 1]
         tmp = DiffEqNoiseProcess.interpolate!(W4, nothing, nothing, t)
         @test _sol.W[end - i + 1] ≈ tmp[1]
         @test _sol.Z[end - i + 1] ≈ tmp[2]

--- a/test/noise_wrapper.jl
+++ b/test/noise_wrapper.jl
@@ -237,7 +237,10 @@ end
     proboop = SDEProblem(f, g, u₀, trange, p)
     soloop = solve(proboop, EM(), dt = dtmix, save_noise = true, save_end = false)
 
-    @test soloop.u ≈ sol.u
+    # save_end = false drops the final time point (matching OrdinaryDiffEq's
+    # documented semantics), so soloop is sol without the t = tspan[2] save.
+    @test soloop.t == sol.t[1:(end - 1)]
+    @test soloop.u ≈ sol.u[1:(end - 1)]
 
     @test length(sol.u) != 1.0e4 + 1
 
@@ -288,9 +291,11 @@ end
 
     @test length(checkWrapper.u) != length(soloop.u)
 
+    # soloop has no save at t = tspan[2] (save_end = false), so checkWrapper's
+    # last two points line up against soloop.u[end] and sol.u[end].
     @test checkWrapper.u[1] ≈ sol.u[indx1] rtol = 1.0e-10
-    @test checkWrapper.u[end - 1] ≈ soloop.u[end - 1] rtol = 1.0e-10
-    @test checkWrapper.u[end] ≈ soloop.u[end] rtol = 1.0e-10
+    @test checkWrapper.u[end - 1] ≈ soloop.u[end] rtol = 1.0e-10
+    @test checkWrapper.u[end] ≈ sol.u[end] rtol = 1.0e-10
     @test checkWrapper.W.W[end] ≈ soloop.W.W[end] rtol = 1.0e-10
     @test checkWrapper(soloop.t[indx1:end]).u ≈ soloop.u[indx1:end] rtol = 1.0e-10
 end

--- a/test/reinit_test.jl
+++ b/test/reinit_test.jl
@@ -225,8 +225,15 @@
 
         prob = SDEProblem(f, g, 1.0, tspan, noise = W, save_noise = true)
 
+        # Construct a fresh transport per trajectory: the ensemble layer skips
+        # reseeding an explicitly passed noise process rng, so trajectories
+        # sharing W duplicate their rv draws under EnsembleThreads and bias the
+        # sampled variance. See https://github.com/SciML/OrdinaryDiffEq.jl/issues/3737
         ensemble_probW = EnsembleProblem(
             prob,
+            prob_func = (p, ctx) -> remake(
+                p, noise = NoiseTransport(0.0, (u, p, t, Y) -> Y * t, randn)
+            ),
             output_func = (sol, ctx) -> (first(sol.W(t)), false)
         )
         solW_at_1 = solve(ensemble_probW, EM(), dt = 1 / 10, trajectories = 40_000)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,10 @@
 using Test, Pkg
 
-const GROUP = get(ENV, "GROUP", "All")
+# The SciML reusable Tests workflow exports GROUP="" when no group input is
+# given; treat that the same as unset so CI doesn't silently run zero tests.
+const GROUP = let g = get(ENV, "GROUP", "All")
+    isempty(g) ? "All" : g
+end
 
 function activate_gpu_env()
     Pkg.activate("gpu")

--- a/test/sde_noise_wrapper.jl
+++ b/test/sde_noise_wrapper.jl
@@ -39,7 +39,9 @@
 
     sol2 = solve(prob1, EM(), dt = dt)
 
-    for i in 1:length(sol1)
+    # length(sol1) counts scalars (4 × timesteps) under the AbstractArray
+    # solution semantics, so index the timeseries explicitly.
+    for i in eachindex(sol1.u)
         @test sol1.u[i] ≈ sol2.u[i]
     end
 


### PR DESCRIPTION
> [!IMPORTANT]
> Please ignore this PR until it has been reviewed by @ChrisRackauckas.

Fixes #276.

## Summary

Issue #276 reported the `noise_wrapper.jl` "Interpolation with small eps jumps" failure on master. Investigating it surfaced that the root **Tests CI has silently run zero tests since May 2024**: the SciML reusable workflow exports `GROUP=""` when no `group:` input is given, and `get(ENV, "GROUP", "All")` returns that empty string, which matches no test group (the green "Tests" jobs go from "Running tests..." to "tests passed" in 0.3 s). Fixing the `GROUP` guard and running the full suite locally then surfaced three more master failures that had accumulated unseen, all fixed here. The suite is green locally on Julia 1.10 with the latest published deps (StochasticDiffEq 7.0.0).

## The fixes

**1. `test/noise_wrapper.jl` — the #276 failure (test was stale).** The 2020 testset assumed `save_end = false` still saves the final time point when `save_everystep` is active. StochasticDiffEq has long since adopted OrdinaryDiffEq's documented semantics (verified empirically on OrdinaryDiffEq latest, StochasticDiffEq 6.102, and 7.0.0: all drop the final point, `soloop.u == sol.u[1:end-1]`), so the end-of-array comparisons were off by one. The "2% drift" in the issue is exactly one EM step of shift; the NoiseWrapper interpolation itself matches to ~1e-15, so there is no solver regression. Testset passes 15/15.

**2. `src/solve.jl` — #278 broke `solve(NoiseProblem(...))` for most noise types.** The endpoint snapping merged 3 days ago in #278 (under the silent CI) accesses `W.save_everystep`/`W.t`, which only `NoiseProcess`/`SimpleNoiseProcess` have. Any other noise type crashed when the end-of-span branch fired: `NoiseFunction` (kills `test/noise_function.jl`, aborting the whole suite) and `VirtualBrownianTree` — **the latter is the live "Self-Hosted Tests / Bridge" failure on master** (`FieldError: type VirtualBrownianTree has no field save_everystep` at `solve.jl:60`). Guarded with `hasfield`.

**3. `src/solve.jl` — #278 also made `test/noise_transport.jl` fail ~70% of the time.** The snap overwrites `curt` after `accept_step!` has prepared the next step at the drifted time, so for function-evaluated noises the exact invariant `dW == W(curt + dt) - curW` broke by 1 ulp depending on the random transport draw (local stress run: 344/500 failures before, 0/500 after). The prepared step is now recomputed at the snapped `curt` for `NoiseFunction`/`NoiseTransport`, whose `calculate_step!` is pure. Stateful processes are deliberately untouched (re-preparing would pop RSwM stacks or hit NoiseGrid domain guards, and their prepared step is random so the sub-eps label drift is unobservable).

**4. `test/sde_noise_wrapper.jl` — stale `length(sol)` assumption.** `length(sol)` on a 4-state solution now counts scalars (4 × 17 = 68) under the AbstractArray solution semantics, so `for i in 1:length(sol1)` overran the 17-timestep arrays with BoundsErrors. Now indexes `eachindex(sol1.u)`.

**5. `test/extraction_test.jl` — endpoint-drift assumption.** The test accumulates query times as `t + dt` floats (ending at `1.0000000000000007`), which matched the solution's drifted final time before #278. The solve now (correctly, per #278's intent) ends exactly at `tspan[2]`, so the last query fell outside the reversed wrapper's domain and missed by ~1e-6 rtol. Now queries the solution's saved times.

**6. `test/runtests.jl` — treat `GROUP=""` as `"All"`** so the existing Tests workflow actually runs the suite again.

## Verification

All run locally on Julia 1.10.11 with latest published deps (StochasticDiffEq v7.0.0, the same resolution as CI):

- Full `Pkg.test()`: all 37 Core1+misc testsets pass, zero failures/errors. The run was killed externally during the final statistical testset (`bridge_test`, machine under load ~160), so `bridge_test.jl` was then run standalone to completion: exit code 0, all testsets pass.
- The previously-crashing VBT ensemble piece (the master Bridge CI failure) verified directly: correct bridge statistics (mean ≈ q, var ≈ q(1−q)).
- NoiseTransport exactness stress test: 344/500 failures before fix 3, 0/500 after.
- Runic check clean on all touched files.

## Notes

- With fix 6, this PR's CI will run the real suite for the first time in two years — Tests and Self-Hosted/Bridge are expected to go green. The strict **Downgrade** job remains naturally red: the loose floors (`SciMLBase = "1, 2, 3"`, `StochasticDiffEq = "6, 7"`, ...) resolve ancient versions the suite no longer supports. #276 lists floors that pass on Julia 1.10 (`SciMLBase = "3.1"`, `StochasticDiffEq = "7"`, `DiffEqBase = "7"`, `RecursiveArrayTools = "4"`, ...); that compat bump is left as a small follow-up PR.
- #282 (canonical grouped-tests CI) touches `test/runtests.jl` too but on different lines (`GROUP` dispatch vs. this guard); the two compose — the guard stays useful for any caller that omits `group:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
