### PR TITLE
Canonicalize tests around @safetestset (isolation, matches OrdinaryDiffEq)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -45,6 +45,7 @@ RecursiveArrayTools = "2, 3, 4"
 ResettableStacks = "0.6, 1.0"
 ReverseDiff = "1"
 SDEProblemLibrary = "0.1, 1"
+SafeTestsets = "0.1, 1"
 SciMLBase = "1, 2, 3"
 StaticArrays = "1"
 StaticArraysCore = "1.4"
@@ -63,10 +64,11 @@ Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
 SDEProblemLibrary = "c72e72a9-a271-4b2b-8966-303ed956772e"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "SDEProblemLibrary", "Pkg", "StatsBase", "StaticArrays", "StochasticDiffEq", "Distributions", "HypothesisTests", "Cubature", "ExplicitImports", "Optim"]
+test = ["Test", "SafeTestsets", "SDEProblemLibrary", "Pkg", "StatsBase", "StaticArrays", "StochasticDiffEq", "Distributions", "HypothesisTests", "Cubature", "ExplicitImports", "Optim"]

--- a/test/BWT_test.jl
+++ b/test/BWT_test.jl
@@ -1,4 +1,4 @@
-@testset "BoxWedgeTail tests" begin
+@safetestset "BoxWedgeTail tests" begin
     using DiffEqNoiseProcess, Test, Random
     import Distributions
     using Cubature

--- a/test/RSwM1_test.jl
+++ b/test/RSwM1_test.jl
@@ -1,4 +1,4 @@
-@testset "RSwM1" begin
+@safetestset "RSwM1" begin
     using DiffEqNoiseProcess
 
     W = WienerProcess(0.0, 0.0, 0.0, rswm = RSWM(adaptivealg = :RSwM1))

--- a/test/RSwM2_test.jl
+++ b/test/RSwM2_test.jl
@@ -1,4 +1,4 @@
-@testset "RSwM2" begin
+@safetestset "RSwM2" begin
     using DiffEqNoiseProcess
 
     W = WienerProcess(0.0, 0.0, rswm = RSWM(adaptivealg = :RSwM2))

--- a/test/RSwM3_test.jl
+++ b/test/RSwM3_test.jl
@@ -1,4 +1,4 @@
-@testset "RSwM3" begin
+@safetestset "RSwM3" begin
     using DiffEqNoiseProcess
 
     W = WienerProcess(0.0, 0.0, 0.0, rswm = RSWM(adaptivealg = :RSwM3))

--- a/test/VBT_test.jl
+++ b/test/VBT_test.jl
@@ -1,4 +1,4 @@
-@testset "Virtual Brownian Tree tests" begin
+@safetestset "Virtual Brownian Tree tests" begin
     using DiffEqNoiseProcess, DiffEqBase, StochasticDiffEq, Test, Random
 
     W = VirtualBrownianTree(0.0, 0.0; tree_depth = 3, search_depth = 5)

--- a/test/abstractarray_shape_test.jl
+++ b/test/abstractarray_shape_test.jl
@@ -1,4 +1,4 @@
-@testset "AbstractNoiseProcess T/N parameterization" begin
+@safetestset "AbstractNoiseProcess T/N parameterization" begin
     using DiffEqNoiseProcess, StochasticDiffEq, Test
 
     # AbstractNoiseProcess <: AbstractDiffEqArray <: AbstractVectorOfArray <: AbstractArray{T, N}

--- a/test/bridge_runningstats.jl
+++ b/test/bridge_runningstats.jl
@@ -1,0 +1,31 @@
+# Shared streaming-statistics helpers for the bridge tests. Each @safetestset in
+# bridge_test.jl runs in its own module, so this file is included into each one to
+# provide the running mean/variance accumulator without retaining full solutions.
+keep_u = (sol, ctx) -> ((u = sol.u,), false)
+
+mutable struct RunningStats
+    n::Int
+    sum::Vector{Float64}
+    sumsq::Vector{Float64}
+    RunningStats() = new(0, Float64[], Float64[])
+end
+function push_stats!(rs::RunningStats, u)
+    if rs.n == 0
+        resize!(rs.sum, length(u))
+        fill!(rs.sum, 0.0)
+        resize!(rs.sumsq, length(u))
+        fill!(rs.sumsq, 0.0)
+    end
+    rs.n += 1
+    for i in eachindex(u)
+        v = first(u[i])
+        rs.sum[i] += v
+        rs.sumsq[i] += abs2(v)
+    end
+    return rs
+end
+stats_mean(rs::RunningStats) = rs.sum ./ rs.n
+function stats_std(rs::RunningStats)
+    m = stats_mean(rs)
+    return sqrt.(max.(rs.sumsq ./ rs.n .- abs2.(m), 0.0) .* (rs.n / (rs.n - 1)))
+end

--- a/test/bridge_test.jl
+++ b/test/bridge_test.jl
@@ -4,37 +4,13 @@
 # value arrays (timestep_mean/timestep_meanvar need `el.u[i]`) and the Ou-Bridge
 # testsets accumulate streaming sums instead of solution collections — only the
 # elementwise mean/std are asserted.
-keep_u = (sol, ctx) -> ((u = sol.u,), false)
-
-mutable struct RunningStats
-    n::Int
-    sum::Vector{Float64}
-    sumsq::Vector{Float64}
-    RunningStats() = new(0, Float64[], Float64[])
-end
-function push_stats!(rs::RunningStats, u)
-    if rs.n == 0
-        resize!(rs.sum, length(u))
-        fill!(rs.sum, 0.0)
-        resize!(rs.sumsq, length(u))
-        fill!(rs.sumsq, 0.0)
-    end
-    rs.n += 1
-    for i in eachindex(u)
-        v = first(u[i])
-        rs.sum[i] += v
-        rs.sumsq[i] += abs2(v)
-    end
-    return rs
-end
-stats_mean(rs::RunningStats) = rs.sum ./ rs.n
-function stats_std(rs::RunningStats)
-    m = stats_mean(rs)
-    return sqrt.(max.(rs.sumsq ./ rs.n .- abs2.(m), 0.0) .* (rs.n / (rs.n - 1)))
-end
-
-@testset "Brownian Bridge" begin
+#
+# The shared streaming-statistics helpers (keep_u, RunningStats, push_stats!,
+# stats_mean, stats_std) live in bridge_runningstats.jl and are included into each
+# @safetestset, since each runs in its own module.
+@safetestset "Brownian Bridge" begin
     using DiffEqNoiseProcess, DiffEqBase, Test, Random, DiffEqBase.EnsembleAnalysis
+    include("bridge_runningstats.jl")
 
     Random.seed!(100)
     W = BrownianBridge(0.0, 1.0, 0.0, 1.0, 0.0, 0.0)
@@ -123,9 +99,10 @@ end
     @test ≈(timestep_meanvar(sol, Int(2^(W.tree_depth) + 1))[2], 0.0, atol = 1.0e-16)
 end
 
-@testset "Scalar Ou-Bridge" begin
+@safetestset "Scalar Ou-Bridge" begin
     using DiffEqNoiseProcess,
         DiffEqBase, Test, Random, DiffEqBase.EnsembleAnalysis, StatsBase, Statistics
+    include("bridge_runningstats.jl")
     stats_forward = RunningStats()
     dt = 0.125
     t_max = 20.0
@@ -169,7 +146,10 @@ end
     @test all(isapprox.(stats_std(stats_forward), stats_std(stats_solver); atol = 1.0e-3))
 end
 
-@testset "Vector Ou-Bridge" begin
+@safetestset "Vector Ou-Bridge" begin
+    using DiffEqNoiseProcess,
+        DiffEqBase, Test, Random, DiffEqBase.EnsembleAnalysis, StatsBase, Statistics
+    include("bridge_runningstats.jl")
     stats_forward = RunningStats()
     dt = 0.125
     t_max = 20.0
@@ -221,7 +201,10 @@ end
     @test all(isapprox.(stats_std(stats_forward), stats_std(stats_solver); atol = 1.0e-3))
 end
 
-@testset "Inplace OU-Bridge" begin
+@safetestset "Inplace OU-Bridge" begin
+    using DiffEqNoiseProcess,
+        DiffEqBase, Test, Random, DiffEqBase.EnsembleAnalysis, StatsBase, Statistics
+    include("bridge_runningstats.jl")
     stats_forward = RunningStats()
     dt = 0.125
     t_max = 20.0

--- a/test/compoundpoisson.jl
+++ b/test/compoundpoisson.jl
@@ -1,4 +1,4 @@
-@testset "CompoundPoissonProcess" begin
+@safetestset "CompoundPoissonProcess" begin
     using DiffEqNoiseProcess, DiffEqBase, Test, Statistics
 
     r = 2

--- a/test/copy_noise_test.jl
+++ b/test/copy_noise_test.jl
@@ -1,4 +1,4 @@
-@testset "Copy Noise test" begin
+@safetestset "Copy Noise test" begin
     using DiffEqNoiseProcess, StochasticDiffEq
     using Optim  # Required for BoxWedgeTail with sqeezing=true
 

--- a/test/correlated.jl
+++ b/test/correlated.jl
@@ -1,6 +1,6 @@
-using StaticArrays
-@testset "Correlated Wiener Process" begin
+@safetestset "Correlated Wiener Process" begin
     using DiffEqNoiseProcess, DiffEqBase, Test, Statistics
+    using StaticArrays
 
     W_not_correlated = WienerProcess(0.0, zeros(2), zeros(2))
     @test W_not_correlated.covariance == nothing
@@ -39,11 +39,11 @@ using StaticArrays
     @test W.covariance ≈ cov(sol, dims = 2) / dt rtol = 1.0e-2
 
     # with StaticArrays
-    Γ = @SMatrix [
-        1.0 ρ
-        ρ 1.0
-    ]
-    W = CorrelatedWienerProcess(Γ, 0.0, @SVector(zeros(2)), @SVector(zeros(2)))
+    # Constructor forms (rather than @SMatrix/@SVector) so the body stays
+    # self-contained inside the @safetestset module, where a package macro
+    # cannot resolve against a `using` that runs in the same testset block.
+    Γ = SMatrix{2, 2}(1.0, ρ, ρ, 1.0)
+    W = CorrelatedWienerProcess(Γ, 0.0, SVector{2}(0.0, 0.0), SVector{2}(0.0, 0.0))
 
     dt = 0.1
     calculate_step!(W, dt, nothing, nothing)

--- a/test/ensemble_test.jl
+++ b/test/ensemble_test.jl
@@ -1,6 +1,8 @@
-using DiffEqNoiseProcess, SciMLBase
-W = WienerProcess(0.0, 1.0, 1.0)
-prob = NoiseProblem(W, (0.0, 1.0))
-ensemble_prob = EnsembleProblem(prob)
-sol = solve(prob; dt = 0.1)
-sol = solve(ensemble_prob, nothing, EnsembleSerial(); trajectories = 100, dt = 0.1)
+@safetestset "Ensemble" begin
+    using DiffEqNoiseProcess, SciMLBase
+    W = WienerProcess(0.0, 1.0, 1.0)
+    prob = NoiseProblem(W, (0.0, 1.0))
+    ensemble_prob = EnsembleProblem(prob)
+    sol = solve(prob; dt = 0.1)
+    sol = solve(ensemble_prob, nothing, EnsembleSerial(); trajectories = 100, dt = 0.1)
+end

--- a/test/explicit_imports_test.jl
+++ b/test/explicit_imports_test.jl
@@ -1,8 +1,7 @@
-using ExplicitImports
-using DiffEqNoiseProcess
-using Test
-
-@testset "ExplicitImports" begin
+@safetestset "ExplicitImports" begin
+    using ExplicitImports
+    using DiffEqNoiseProcess
+    using Test
     @test check_no_implicit_imports(DiffEqNoiseProcess) === nothing
     @test check_no_stale_explicit_imports(DiffEqNoiseProcess) === nothing
 end

--- a/test/extraction_test.jl
+++ b/test/extraction_test.jl
@@ -1,4 +1,4 @@
-@testset "Noise Extraction Test" begin
+@safetestset "Noise Extraction Test" begin
     using Random, DiffEqNoiseProcess, DiffEqBase, Test
     seed = 100
     Random.seed!(seed)

--- a/test/geometric_bm.jl
+++ b/test/geometric_bm.jl
@@ -1,4 +1,4 @@
-@testset "GeometricBM" begin
+@safetestset "GeometricBM" begin
     using DiffEqNoiseProcess, DiffEqBase, Test, Statistics
 
     μ = 1.0

--- a/test/interpolation_test.jl
+++ b/test/interpolation_test.jl
@@ -1,4 +1,4 @@
-@testset "Noise Interpolation Test" begin
+@safetestset "Noise Interpolation Test" begin
     using DiffEqNoiseProcess
 
     W = WienerProcess(0.0, 0.0, 0.0)

--- a/test/multi_dim.jl
+++ b/test/multi_dim.jl
@@ -1,4 +1,4 @@
-@testset "Multidim" begin
+@safetestset "Multidim" begin
     using DiffEqNoiseProcess, Random, Statistics
 
     W = WienerProcess(0.0, rand(4, 4), rswm = RSWM(adaptivealg = :RSwM3))

--- a/test/noise_approximation.jl
+++ b/test/noise_approximation.jl
@@ -1,4 +1,4 @@
-@testset "NoiseApproximation" begin
+@safetestset "NoiseApproximation" begin
     using DiffEqNoiseProcess, DiffEqBase, StochasticDiffEq
     using Test
 

--- a/test/noise_function.jl
+++ b/test/noise_function.jl
@@ -1,4 +1,4 @@
-@testset "NoiseFunction" begin
+@safetestset "NoiseFunction" begin
     using DiffEqNoiseProcess, DiffEqBase, Test
     f = (u, p, t) -> exp(t)
 

--- a/test/noise_grid.jl
+++ b/test/noise_grid.jl
@@ -1,4 +1,4 @@
-@testset "NoiseGrid" begin
+@safetestset "NoiseGrid" begin
     using DiffEqNoiseProcess, DiffEqBase, Test
 
     t = 0:0.001:1

--- a/test/noise_transport.jl
+++ b/test/noise_transport.jl
@@ -1,5 +1,5 @@
-@testset "NoiseTransport" begin
-    using DiffEqNoiseProcess, Distributions, Random, Test
+@safetestset "NoiseTransport" begin
+    using DiffEqNoiseProcess, DiffEqBase, Distributions, Random, Test
 
     # test steps
     f = (u, p, t, Y) -> exp(Y * t)

--- a/test/noise_wrapper.jl
+++ b/test/noise_wrapper.jl
@@ -1,6 +1,6 @@
-using DiffEqNoiseProcess, Test, Random
-using StochasticDiffEq, LinearAlgebra
-@testset "NoiseWrapper" begin
+@safetestset "NoiseWrapper" begin
+    using DiffEqNoiseProcess, Test, Random
+    using StochasticDiffEq, LinearAlgebra
     _W = WienerProcess(0.0, 0.0, 0.0)
 
     dt = 0.1
@@ -84,7 +84,9 @@ using StochasticDiffEq, LinearAlgebra
     @test W2.W[end] ≈ _W.W[end - 1]
 end
 
-@testset "NoiseWrapper restart tests to interpolate" begin
+@safetestset "NoiseWrapper restart tests to interpolate" begin
+    using DiffEqNoiseProcess, Test, Random
+    using StochasticDiffEq, LinearAlgebra
     seed = 100
     u₀ = [0.75, 0.5]
     p = [-1.5, 0.05, 0.2, 0.01]
@@ -202,7 +204,9 @@ end
     @show checkGrid.u[end] - sol.u[end]
 end
 
-@testset "Interpolation with small eps jumps" begin
+@safetestset "Interpolation with small eps jumps" begin
+    using DiffEqNoiseProcess, Test, Random
+    using StochasticDiffEq, LinearAlgebra
     seed = 100
     u₀ = [1.0]
     p = [1.1, 0.87]
@@ -300,7 +304,9 @@ end
     @test checkWrapper(soloop.t[indx1:end]).u ≈ soloop.u[indx1:end] rtol = 1.0e-10
 end
 
-@testset "Diagonal to Non-diagonal NoiseProcess conversion" begin
+@safetestset "Diagonal to Non-diagonal NoiseProcess conversion" begin
+    using DiffEqNoiseProcess, Test, Random
+    using StochasticDiffEq, LinearAlgebra
     t = 0.0
     dtleft = 0.01
     rand_prototype = [0.0 0.0 0.0; 0.0 0.0 0.0]

--- a/test/ornstein.jl
+++ b/test/ornstein.jl
@@ -1,4 +1,4 @@
-@testset "OU" begin
+@safetestset "OU" begin
     using DiffEqNoiseProcess, DiffEqBase, Test, Statistics
     Θ = 1.0
     μ = 1.2

--- a/test/pcn_test.jl
+++ b/test/pcn_test.jl
@@ -1,4 +1,4 @@
-@testset "preconditioned Crank Nicolson tests" begin
+@safetestset "preconditioned Crank Nicolson tests" begin
     using DiffEqNoiseProcess, Test, Random
     using Statistics
     using DiffEqBase

--- a/test/reinit_test.jl
+++ b/test/reinit_test.jl
@@ -1,4 +1,4 @@
-@testset "Reinit" begin
+@safetestset "Reinit" begin
     using StochasticDiffEq, DiffEqNoiseProcess, Statistics
 
     f = (u, p, t) -> 1.0

--- a/test/restart_test.jl
+++ b/test/restart_test.jl
@@ -1,4 +1,4 @@
-@testset "Restart" begin
+@safetestset "Restart" begin
     using Test, LinearAlgebra
     using StochasticDiffEq, DiffEqNoiseProcess
     using Random

--- a/test/reversal_test.jl
+++ b/test/reversal_test.jl
@@ -1,5 +1,5 @@
-using StochasticDiffEq, DiffEqNoiseProcess, Test, Random
-@testset "SDE Stratonovich Reversal Tests" begin
+@safetestset "SDE Stratonovich Reversal Tests" begin
+    using StochasticDiffEq, DiffEqNoiseProcess, Test, Random
     Random.seed!(100)
     α = 1.01
     β = 0.87
@@ -145,7 +145,8 @@ using StochasticDiffEq, DiffEqNoiseProcess, Test, Random
     @test sol1.u ≈ sol2.u atol = 1.0e-5
 end
 
-@testset "Reverse a given NoiseProcess " begin
+@safetestset "Reverse a given NoiseProcess " begin
+    using StochasticDiffEq, DiffEqNoiseProcess, Test, Random
     # Noise Wrapper
     _W = WienerProcess(0.0, 0.0, 0.0)
 
@@ -199,7 +200,8 @@ end
     @test isapprox(sol.Z, reverse(sol2.Z), atol = 1.0e-12)
 end
 
-@testset "SDE Ito Basic Reversal Tests" begin
+@safetestset "SDE Ito Basic Reversal Tests" begin
+    using StochasticDiffEq, DiffEqNoiseProcess, Test, Random
     n = 100000
     T = 2.0
     dt = T / n
@@ -281,7 +283,8 @@ end
 Some more Ito reversals
 """
 
-@testset "SDE Ito Reversal Tests" begin
+@safetestset "SDE Ito Reversal Tests" begin
+    using StochasticDiffEq, DiffEqNoiseProcess, Test, Random
     Random.seed!(100)
     α = 1.0
     β = 0.3
@@ -349,7 +352,8 @@ Some more Ito reversals
     # plot(vcat(sol.u - reverse(sol1.u) ...))
 end
 
-@testset "SDE Ito additive noise Reversal Tests" begin
+@safetestset "SDE Ito additive noise Reversal Tests" begin
+    using StochasticDiffEq, DiffEqNoiseProcess, Test, Random
     using SDEProblemLibrary: prob_sde_additive, prob_sde_additivesystem
     Random.seed!(100)
     dt = 1.0e-3

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Test, Pkg
+using Test, Pkg, SafeTestsets
 
 # The SciML reusable Tests workflow exports GROUP="" when no group input is
 # given; treat that the same as unset so CI doesn't silently run zero tests.

--- a/test/savestep_test.jl
+++ b/test/savestep_test.jl
@@ -1,4 +1,4 @@
-@testset "save_everystep Keyword" begin
+@safetestset "save_everystep Keyword" begin
     #Test whether the result of the process is dependent on 'save_everystep'.
     using DiffEqNoiseProcess, DiffEqBase, Test, Statistics, Random
     processes = [
@@ -23,7 +23,7 @@
     end
 end
 
-@testset "Noise solution lands exactly on the endpoint" begin
+@safetestset "Noise solution lands exactly on the endpoint" begin
     # A NoiseProblem solve must stop exactly on tspan[2] and never step past it.
     # Floating point drift accumulated over many steps is ~eps(tspan[2]), which can be
     # far larger than eps(dt) for small dt, so the end correction must be scaled by the

--- a/test/sde_adaptivedistribution_tests.jl
+++ b/test/sde_adaptivedistribution_tests.jl
@@ -1,6 +1,8 @@
-@testset "SDE Adaptive Distribution Tests" begin
+@safetestset "SDE Adaptive Distribution Tests" begin
     using StochasticDiffEq, StatsBase, Distributions, HypothesisTests
+    using DiffEqNoiseProcess
     using Random
+    import SDEProblemLibrary: prob_sde_linear
 
     prob = prob_sde_linear
     Random.seed!(200)

--- a/test/sde_noise_wrapper.jl
+++ b/test/sde_noise_wrapper.jl
@@ -1,4 +1,4 @@
-@testset "SDE NoiseWrapper" begin
+@safetestset "SDE NoiseWrapper" begin
     using StochasticDiffEq, DiffEqBase, DiffEqNoiseProcess, Test
 
     f1 = (u, p, t) -> 1.01u

--- a/test/simple_noise_bigfloat_test.jl
+++ b/test/simple_noise_bigfloat_test.jl
@@ -2,8 +2,9 @@
 # Tests that SimpleWienerProcess correctly passes dW as first argument to dist/bridge functions
 # Before PR #230, this would fail with BigFloat because WHITE_NOISE_DIST uses dW to determine output type
 
-@testset "SimpleNoiseProcess BigFloat" begin
+@safetestset "SimpleNoiseProcess BigFloat" begin
     using DiffEqNoiseProcess
+    using Test
 
     # Test 1: Out-of-place SimpleWienerProcess with BigFloat scalar
     @testset "Scalar BigFloat (out-of-place)" begin

--- a/test/two_processes.jl
+++ b/test/two_processes.jl
@@ -1,8 +1,8 @@
-using DiffEqBase, DiffEqNoiseProcess, Test, LinearAlgebra
-using Random
-seed = 100;
-Random.seed!(seed);
-@testset "Two noise processes for different m" begin
+@safetestset "Two noise processes for different m" begin
+    using DiffEqBase, DiffEqNoiseProcess, Test, LinearAlgebra
+    using Random
+    seed = 100
+    Random.seed!(seed)
     for m in 1:4
         rand_prototype = zeros(m)
         rand_prototype2 = similar(rand_prototype, Int(m * (m - 1) / 2))


### PR DESCRIPTION
## What

Make each independent test unit run in its own module via `@safetestset`, matching OrdinaryDiffEq's canonical test structure (per-unit isolation + world-age safety). Previously the suite used plain `@testset` units `include`d into a shared `Main`, so units silently depended on `using`s and symbols that leaked in from earlier-running files.

## How

Each top-level `@testset "X" begin ... end` unit becomes `@safetestset "X" begin ... end`, and each body is made self-contained:

- The `using`/`import` lines a body relies on are duplicated into each unit (hoisted from the file top into the `@safetestset` body).
- `noise_transport.jl`: added `DiffEqBase` — `NoiseProblem`/`solve` come from there, not from `DiffEqNoiseProcess`; the old code relied on leakage.
- `sde_adaptivedistribution_tests.jl`: added `using DiffEqNoiseProcess` and `import SDEProblemLibrary: prob_sde_linear` (previously leaked in from `noise_approximation.jl`).
- `noise_wrapper.jl` / `reversal_test.jl`: each top-level unit got its own import block (these files had multiple top-level `@testset`s sharing one file-level `using`).
- `correlated.jl`: a package-provided macro (`@SMatrix`/`@SVector`) cannot resolve against a `using` that runs inside the same `@testset`/`@safetestset` block, so those two calls now use the equivalent `SMatrix{2,2}(...)` / `SVector{2}(...)` constructors. Same arrays, same assertions.
- `bridge_test.jl`: the shared streaming-statistics helpers (`keep_u`, `RunningStats`, `push_stats!`, `stats_mean`, `stats_std`) are extracted to a new `test/bridge_runningstats.jl` and `include`d into each of the four `@safetestset`s.

Nested grouping `@testset`s inside a unit stay plain `@testset` — the unit-level `@safetestset` already provides isolation. The `GROUP`-dispatch ladder in `runtests.jl` and `qa/qa_tests.jl` are unchanged. No test logic or assertions were changed.

Adds `SafeTestsets` to the test deps (`[extras]` + `[targets].test` + `[compat] SafeTestsets = "0.1, 1"`).

## Verification

`GROUP=Core` `Pkg.test()` passes locally on Julia 1.11 with every unit now running as its own isolated module. All assertion-bearing units report the same pass counts as before the change (the few units with `Total = 0` have no `@test` assertions; they only exercise code paths, matching prior behavior).

---

This is a pilot for fan-out across SciML repos. Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)