### PR TITLE
Raise SciMLBase compat floor to 3 (fix Downgrade CI)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqNoiseProcess"
 uuid = "77a26b50-5914-5dd7-bc55-306e6241c503"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "5.32.0"
+version = "5.32.1"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
@@ -45,7 +45,7 @@ ResettableStacks = "0.6, 1.0"
 ReverseDiff = "1"
 SDEProblemLibrary = "1"
 SafeTestsets = "0.0.1, 0.1"
-SciMLBase = "1, 2, 3"
+SciMLBase = "3"
 SciMLTesting = "1"
 StaticArrays = "1"
 StaticArraysCore = "1.4"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqNoiseProcess"
 uuid = "77a26b50-5914-5dd7-bc55-306e6241c503"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "5.32.1"
+version = "5.32.2"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
@@ -45,7 +45,7 @@ ResettableStacks = "0.6, 1.0"
 ReverseDiff = "1"
 SDEProblemLibrary = "1"
 SafeTestsets = "0.0.1, 0.1"
-SciMLBase = "3"
+SciMLBase = "3.4.3"
 SciMLTesting = "1"
 StaticArrays = "1"
 StaticArraysCore = "1.4"


### PR DESCRIPTION
## Problem

The `Downgrade (lts)` CI job is red on master. `test/bridge_test.jl` (Brownian Bridge testset) fails with 22 errors of the form:

```
MethodError: no method matching getindex(::@NamedTuple{u::Vector{Float64}})
  @ SciMLBase.EnsembleAnalysis ensemble_analysis.jl  (timestep_mean / timestep_meanvar)
```

## Root cause

`test/bridge_test.jl` uses a memory-saving `output_func`:

```julia
keep_u = (sol, ctx) -> ((u = sol.u,), false)
```

so each ensemble element is a `(u = vec,)` NamedTuple. It then asserts on `timestep_mean(sol, i)` / `timestep_meanvar(sol, i)`, which iterate via `EnsembleAnalysis.get_timestep`.

- SciMLBase **< 3.4.3** defines `get_timestep(sim, i) = (sol.u[i] for sol in sim)` (iterating the `EnsembleSolution` directly).
- SciMLBase **>= 3.4.3** defines `get_timestep(sim, i) = (sol.u[i] for sol in sim.u)` (iterating the stored NamedTuple vector), which is what the `keep_u` trick requires.

The `sim` → `sim.u` change landed in SciMLBase commit `e17a6de1c`, first released in **v3.4.3**. So all of 3.0.0–3.4.2 (and 1.x/2.x) are incompatible with this test code.

The original fix in this PR raised the floor only to `SciMLBase = "3"`, but the Downgrade resolver picks the **minimum** satisfying version — **v3.1.0** — which still has the old `for sol in sim` form, so the job stayed red (the exact `getindex(::NamedTuple)` error above).

## Fix

Raise the compat floor to the true minimum the test requires: `SciMLBase = "3.4.3"`. Patch-bump to 5.32.2.

## Local verification (Julia 1.10 / lts — the failing channel)

- With SciMLBase pinned to the new downgrade-floor **v3.4.3**, `get_timestep` resolves to `(sol.u[i] for sol in sim.u)` and the previously-erroring `timestep_mean`/`timestep_meanvar` calls succeed (test passes 4/4).
- The prior PR #289 CI run (floor `3`) resolved SciMLBase to **v3.1.0** and produced the exact NamedTuple `getindex` error, confirming the floor of `3` was insufficient.

Please ignore until reviewed by @ChrisRackauckas