### PR TITLE
Snap NoiseProblem endpoint when dt is coarser precision than the time type

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqNoiseProcess"
 uuid = "77a26b50-5914-5dd7-bc55-306e6241c503"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "5.32.2"
+version = "5.32.3"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -53,14 +53,27 @@ function DiffEqBase.__solve(
 
     setup_next_step!(W, nothing, nothing)
     tType = typeof(W.curt)
+    dtType = typeof(dt)
     while W.curt < prob.tspan[2]
         # Tolerance scaled by the magnitude of the time values rather than by `dt`:
         # the floating point drift accumulated over many steps is on the order of
         # `eps(tspan[2])`, which can be far larger than `eps(dt)` when `dt` is small.
         # The previous `100 * eps(dt)` tolerance was therefore essentially never hit,
         # so the solve took a full extra step and stopped past `tspan[2]`.
+        #
+        # When `dt` is given at a coarser precision than the time type (e.g. a Float32
+        # `dt = 1/50f0` with a Float64 tspan), the per-step error is set by `dt`'s
+        # precision, so the drift accumulated over the span reaches ~`eps(dtType(tspan[2]))`
+        # (~1e-7 for Float32) — orders of magnitude larger than `eps(tType(tspan[2]))`
+        # (~1e-16 for Float64). Use the coarser of the two so the near-endpoint step is
+        # snapped onto `tspan[2]` instead of having a sub-`dt` sliver step appended past it.
+        mag = max(abs(prob.tspan[2]), abs(W.curt))
         endtol = tType <: AbstractFloat ?
-            100 * eps(tType(max(abs(prob.tspan[2]), abs(W.curt)))) : zero(W.curt)
+            100 * max(
+                eps(tType(mag)),
+                dtType <: AbstractFloat ? eps(dtType(mag)) : zero(tType(mag))
+            ) :
+            zero(W.curt)
         if tType <: AbstractFloat && abs(prob.tspan[2] - (W.curt + W.dt)) <= endtol
             # The prepared step lands on `tspan[2]` up to floating point drift. Take it as
             # usual but snap the recorded endpoint exactly onto `tspan[2]` so the solution

--- a/test/savestep_test.jl
+++ b/test/savestep_test.jl
@@ -54,4 +54,21 @@ end
             @test issorted(sol.t)
         end
     end
+
+    # A Float32 dt with a Float64 tspan: the per-step error is set by dt's (coarser)
+    # precision, so `0.0:dt:1.0` lands ~2e-8 short of 1.0. The end correction must snap
+    # onto tspan[2] rather than append a sub-dt sliver point past the last grid point
+    # (which produced an off-by-one extra sample, SciML/NeuralPDE.jl#1077).
+    @testset "Float32 dt, Float64 tspan: process = $(proc.dist)" for proc in processes
+        @testset "dt = $dt" for dt in (1 / 50.0f0, 1 / 100.0f0)
+            cproc = deepcopy(proc)
+            prob = NoiseProblem(cproc, (0.0, 1.0); seed = 1234)
+            sol = solve(prob; dt = dt)
+            @test sol.t[end] == 1.0
+            @test sol.curt == 1.0
+            @test issorted(sol.t)
+            # No spurious extra point: the grid has exactly length(0.0:dt:1.0) samples.
+            @test length(sol.t) == length(0.0:Float64(dt):1.0)
+        end
+    end
 end


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.**

## Problem

`solve(::NoiseProblem; dt)` appends a spurious extra point past the last grid point when `dt` is a lower-precision float than the time type — e.g. a Float32 `dt = 1/50f0` with a Float64 `tspan = (0.0, 1.0)`:

```
length(sol.u) = 52   # expected 51 (== length(0.0:dt:1.0))
sol.t[end-2:end] = [0.97999998, 0.99999998, 1.0]
```

The last two points are `0.99999998` (the 51st grid point) and a `2.2e-8`-wide sliver step to `1.0`. This off-by-one surfaced as the red `NNSDE1` lane in SciML/NeuralPDE.jl#1077 (`DimensionMismatch: tried to assign 52-element array to 51×1 destination`).

## Root cause

`dt = 1/50f0` is `0.02f0` (Float32, value `0.019999999552965164`). Stepping `curt += dt` 50 times lands at `0.99999998`, short of `1.0` by `~2.2e-8`, because the per-step error is governed by `dt`'s **Float32** precision. The end-of-span tolerance introduced in #278 only used `eps` at the **Float64** time type:

```julia
endtol = 100 * eps(tType(max(abs(tspan[2]), abs(curt))))   # ~2.2e-14
```

`2.2e-8 ≫ 2.2e-14`, so the near-endpoint step was classified as a genuine undershoot and the overshoot branch appended a sub-`dt` correction point at exactly `1.0` instead of snapping the existing point.

## Fix

Scale the tolerance by the **coarser** of the time type's and `dt`'s precision:

```julia
endtol = 100 * max(eps(tType(mag)),
                   dtType <: AbstractFloat ? eps(dtType(mag)) : zero(tType(mag)))
```

For a Float32 `dt`, `eps(Float32(1.0)) ≈ 1.19e-7 > 2.2e-8`, so the near-endpoint step takes the existing snap branch: it is accepted and the recorded endpoint is snapped exactly onto `tspan[2]`, with no extra point.

For a Float64 `dt`, `dtType == tType`, so the tolerance is **byte-identical** to before — the Float64 path (and the `BrownianBridge` endpoint pinning `bridge_test` depends on) is unchanged.

This fixes the NeuralPDE.jl#1077 failure at the root: the noise solve now yields `length(0.0:dt:1.0)` samples landing exactly on `tspan[2]`, so the NNSDE1 tests need no workaround.

## Verification (run locally, Julia 1.10.11, isolated depot)

* Repro before fix: `length(sol.u) = 52` for `dt = 1/50f0`, `52`→`102` for `1/100f0`.
* After fix: `51` and `101` points respectively, `sol.t[end] == sol.curt == 1.0`, `issorted(sol.t)`.
* `test/savestep_test.jl`: **96/96 Pass** (64 existing + 32 new Float32-`dt` regression asserts).
* `BrownianBridge` endpoint pinning (`dt ∈ {0.1, 0.03, 1/3}`) and clean Float64 dividing `dt`: unchanged, all pass.
* `Runic` clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)