### PR TITLE
Document exported in-place noise constructors

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -113,7 +113,7 @@ All noise processes in this package maintain mathematical rigor through:
 ## Contributing
 
   - Please refer to the
-    [SciML ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://github.com/SciML/ColPrac/blob/master/README.md)<!-- ignore linkcheck -->
+    [SciML ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://docs.sciml.ai/ColPrac/)
     for guidance on PRs, issues, and other matters relating to contributing to SciML.
 
   - See the [SciML Style Guide](https://github.com/SciML/SciMLStyle) for common coding practices and other style decisions.

--- a/src/types.jl
+++ b/src/types.jl
@@ -1300,6 +1300,16 @@ function VirtualBrownianTree(
     return VirtualBrownianTree{false}(t0, W0, Z0, dist, bridge; kwargs...)
 end
 
+"""
+    VirtualBrownianTree!(t0, W0, Z0 = nothing,
+        dist = INPLACE_WHITE_NOISE_DIST, bridge = INPLACE_VBT_BRIDGE; kwargs...)
+
+Construct an in-place `VirtualBrownianTree` noise process.
+
+This is the mutating-distribution variant of [`VirtualBrownianTree`](@ref). It
+uses `dist` and `bridge` functions that write noise increments into their output
+argument, which is useful when `W0` is an array-like noise prototype.
+"""
 function VirtualBrownianTree!(
         t0, W0, Z0 = nothing, dist = INPLACE_WHITE_NOISE_DIST,
         bridge = INPLACE_VBT_BRIDGE; kwargs...
@@ -1532,6 +1542,16 @@ function BoxWedgeTail(
     return BoxWedgeTail{false}(t0, W0, Z0, dist, bridge; kwargs...)
 end
 
+"""
+    BoxWedgeTail!(t0, W0, Z0 = nothing,
+        dist = INPLACE_WHITE_NOISE_DIST, bridge = INPLACE_WHITE_NOISE_BRIDGE; kwargs...)
+
+Construct an in-place `BoxWedgeTail` noise process.
+
+This is the mutating-distribution variant of [`BoxWedgeTail`](@ref) for
+two-dimensional Brownian processes with stochastic area. The supplied `dist` and
+`bridge` functions must write their increments into the provided output arrays.
+"""
 function BoxWedgeTail!(
         t0, W0, Z0 = nothing, dist = INPLACE_WHITE_NOISE_DIST,
         bridge = INPLACE_WHITE_NOISE_BRIDGE; kwargs...


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary
- Add source docstrings for the exported `VirtualBrownianTree!` and `BoxWedgeTail!` constructors.
- Update the ColPrac link to the canonical docs.sciml.ai URL so Documenter linkcheck does not hit the GitHub README URL that returned HTTP 429 locally.

## Audit
- Explicit exports audited: 42
- `public` / `@public` / `SciMLPublic` markers found: 0
- Missing source docstrings after this change: 0
- Missing rendered docs entries after this change: 0

## Verification
- `/home/crackauc/.juliaup/bin/julia +1.10 -e 'using Runic; exit(Runic.main(ARGS))' -- --check --diff --lines=1303:1318 --lines=1545:1560 src/types.jl`\n- `/home/crackauc/.juliaup/bin/julia +1.10 --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); include("docs/make.jl")'`\n- `/home/crackauc/.juliaup/bin/julia +1.10 --project=. -e 'using Pkg; Pkg.test()'`\n\nPrompt/task: audit exported/public API documentation coverage for `SciML/DiffEqNoiseProcess.jl` and open a small draft PR with tests/docs verification.