### PR TITLE
Add public API documentation QA

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,5 +1,75 @@
 using SciMLTesting, DiffEqNoiseProcess, JET, Test
 
+function _public_marker_name(token)
+    token = strip(token)
+    token = replace(token, r"^\s*:" => "")
+    token = replace(token, r"^Symbol\(\"(.+)\"\)$" => s"\1")
+    return Symbol(token)
+end
+
+function _parse_public_marker_names(names)
+    return [_public_marker_name(token) for token in split(names, ",") if !isempty(strip(token))]
+end
+
+function _declared_public_api()
+    api = Set{Symbol}()
+    src_root = joinpath(pkgdir(DiffEqNoiseProcess), "src")
+    for (root, _, files) in walkdir(src_root)
+        for file in files
+            endswith(file, ".jl") || continue
+            for line in eachline(joinpath(root, file))
+                line = strip(split(line, '#'; limit = 2)[1])
+                for marker in ("export", "public", "@public")
+                    m = match(Regex("^" * marker * "\\s+(.+)\$"), line)
+                    m === nothing || union!(api, _parse_public_marker_names(m.captures[1]))
+                end
+                for m in eachmatch(r"Expr\(\s*:public\s*,\s*(.*?)\)", line)
+                    union!(api, _parse_public_marker_names(m.captures[1]))
+                end
+            end
+        end
+    end
+    return sort!(collect(api))
+end
+
+function _rendered_docs_entries()
+    entries = Set{Symbol}()
+    docs_root = joinpath(pkgdir(DiffEqNoiseProcess), "docs", "src")
+    for (root, _, files) in walkdir(docs_root)
+        for file in files
+            endswith(file, ".md") || continue
+            in_docs_block = false
+            for line in eachline(joinpath(root, file))
+                line = strip(line)
+                if line == "```@docs"
+                    in_docs_block = true
+                    continue
+                elseif startswith(line, "```")
+                    in_docs_block = false
+                    continue
+                end
+                in_docs_block || continue
+                isempty(line) && continue
+                name = replace(line, r"\(.*" => "")
+                name = split(name, ".")[end]
+                push!(entries, Symbol(name))
+            end
+        end
+    end
+    return entries
+end
+
+@testset "public API documentation coverage" begin
+    public_api = _declared_public_api()
+
+    missing_docstrings = filter(name -> !Docs.hasdoc(DiffEqNoiseProcess, name), public_api)
+    @test missing_docstrings == Symbol[]
+
+    rendered_entries = _rendered_docs_entries()
+    missing_rendered_entries = filter(name -> name ∉ rendered_entries, public_api)
+    @test missing_rendered_entries == Symbol[]
+end
+
 run_qa(
     DiffEqNoiseProcess;
     explicit_imports = true,


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary

- Adds a QA regression check for DiffEqNoiseProcess's declared public API documentation coverage.
- Derives public API names from source `export`, Julia `public`, SciMLPublic `@public`, and `Expr(:public, ...)` markers.
- Verifies each declared public name has a source docstring via `Docs.hasdoc` and appears in rendered package docs through a Documenter `@docs` block.

## Audit result

The current audit found 42 explicit exports. There are no current `public`, `@public`, or `SciMLPublic` public markings in this package source, and all explicit exports already had source docstrings plus rendered docs entries. This PR adds coverage to keep that true.

## Validation

- `julia -m Runic -i test/qa/qa.jl`
- `julia -m Runic --check test/qa/qa.jl`
- `timeout 3600 env JULIA_DEPOT_PATH=... julia --project=test/qa test/qa/qa.jl`
- `timeout 3600 env JULIA_DEPOT_PATH=... julia --project=docs docs/make.jl`

The docs build completed successfully. It emitted existing Documenter warnings for duplicate legacy/API `@docs` entries and an unqualified non-exported `AbstractNoiseProcess` docs entry under the repository's current `warnonly` settings.