### PR TITLE
Target StochasticDiffEq monorepo downstream tests

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -14,9 +14,9 @@ jobs:
         julia-version: [1]
         os: [ubuntu-latest]
         package:
-          - {user: SciML, repo: StochasticDiffEq.jl, group: Interface}
-          - {user: SciML, repo: StochasticDiffEq.jl, group: Interface2}
-          - {user: SciML, repo: StochasticDiffEq.jl, group: Interface3}
+          - {user: SciML, repo: OrdinaryDiffEq.jl, subdir: lib/StochasticDiffEq, group: Interface1}
+          - {user: SciML, repo: OrdinaryDiffEq.jl, subdir: lib/StochasticDiffEq, group: Interface2}
+          - {user: SciML, repo: OrdinaryDiffEq.jl, subdir: lib/StochasticDiffEq, group: Interface3}
           - {user: SciML, repo: SciMLSensitivity.jl, group: SDE1}
           - {user: SciML, repo: SciMLSensitivity.jl, group: SDE2}
           - {user: SciML, repo: SciMLSensitivity.jl, group: SDE3}
@@ -26,5 +26,6 @@ jobs:
       os: "${{ matrix.os }}"
       owner: "${{ matrix.package.user }}"
       repo: "${{ matrix.package.repo }}"
+      subdir: "${{ matrix.package.subdir }}"
       group: "${{ matrix.package.group }}"
     secrets: "inherit"


### PR DESCRIPTION
Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- retarget the three stale `StochasticDiffEq.jl` downstream rows to `OrdinaryDiffEq.jl`
- select the registered package at `lib/StochasticDiffEq`
- correct the first group name from the removed `Interface` alias to canonical `Interface1`
- forward the matrix `subdir` to the reusable workflow

## Why

StochasticDiffEq moved into the OrdinaryDiffEq monorepo. The old repository/group combinations can no longer test the registered package, and the reusable workflow previously had no subdirectory input at this call site.

This PR depends on:

- SciML/.github#115 for reusable-workflow subdirectory support
- SciML/OrdinaryDiffEq.jl#3909 for generic `GROUP` forwarding in the StochasticDiffEq test runner

## Local verification

Using the local OrdinaryDiffEq monorepo package at `lib/StochasticDiffEq` and the exact requested groups:

- `GROUP=Interface1`: package tests passed; solver-reversal set 152/152
- `GROUP=Interface2`: package tests passed; final sets included element-wise tolerances 12/12, zeroed noise 13/13, scalar 1/1, stiffness detection 5/5, adaptive SDE linear 16/16, and RODE interpolation 11/11
- `GROUP=Interface3`: package tests passed; utility tests 12/12 and iterated-integral tests 66/66
- actionlint: passed
- Runic 1.7 repository check: passed
- `git diff --check`: passed