### PR TITLE
Enable rendered public docs QA

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -20,6 +20,7 @@ run_qa(
     # Unexpected Pass there.
     # Tracked in https://github.com/SciML/DiffEqNoiseProcess.jl/issues/283
     jet_broken = VERSION >= v"1.12",
+    api_docs_kwargs = (; rendered = true),
     ei_kwargs = (;
         # @.. (FastBroadcast) and DEIntegrator (SciMLBase) are re-exported by
         # DiffEqBase but owned elsewhere; imported via DiffEqBase by convention.


### PR DESCRIPTION
## Summary
- enable SciMLTesting rendered public-docs QA with `api_docs_kwargs = (; rendered = true)`
- keep the PR scoped to docs/QA coverage only

Ignore this PR until reviewed by @ChrisRackauckas.

## Validation
- `git diff --check`
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=test/qa -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); include("test/qa/qa.jl")'`\n- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=. -e 'using Pkg; Pkg.test()'`\n- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 -e 'using Pkg; Pkg.activate(; temp=true); Pkg.add("Runic"); using Runic; code = Runic.main(["--check", "."]); code === nothing ? exit(0) : exit(code)'`\n\nDocs build was not run because no docs pages or docstrings changed.