### PR TITLE
Enforce strict DiffEqNoiseProcess documentation

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,8 +9,7 @@ makedocs(
     sitename = "DiffEqNoiseProcess.jl",
     authors = "Chris Rackauckas",
     modules = [DiffEqNoiseProcess],
-    clean = true, doctest = false, linkcheck = true,
-    warnonly = [:docs_block, :missing_docs],
+    clean = true, linkcheck = true,
     format = Documenter.HTML(
         assets = ["assets/favicon.ico"],
         canonical = "https://docs.sciml.ai/DiffEqNoiseProcess/stable/"

--- a/docs/src/abstract_noise_processes.md
+++ b/docs/src/abstract_noise_processes.md
@@ -23,12 +23,6 @@ with `tmid` or when the maximum depth of the tree is reached.
 Lastly, the `NoiseFunction` allows you to use any function of time as the
 noise process, while `NoiseTransport` lets you define a random process as the transport of a random variable or a random vector by a time-dependent function. Together, these functionalities allow you to define any colored noise process and use it efficiently and accurately in your simulations.
 
-## The Standard `AbstractNoiseProcess`
-
-```@docs
-NoiseProcess
-```
-
 ## Alternative `AbstractNoiseProcess` Types
 
 In addition to the mathematically-defined noise processes above, there exists
@@ -36,14 +30,4 @@ more generic functionality for building noise processes from other noise process
 from arbitrary functions, from arrays, and from approximations of stochastic
 differential equations.
 
-```@docs
-NoiseWrapper
-NoiseFunction
-NoiseTransport
-NoiseGrid
-NoiseApproximation
-VirtualBrownianTree
-SimpleNoiseProcess
-BoxWedgeTail
-pCN
-```
+See the [Noise Processes API](@ref) for the constructor reference.

--- a/docs/src/api/interface.md
+++ b/docs/src/api/interface.md
@@ -12,21 +12,6 @@ setup_next_step!
 save_noise!
 ```
 
-## Noise Process Types
-
-### Abstract Types
-
-```@docs
-AbstractNoiseProcess
-```
-
-### Core Types
-
-```@docs
-NoiseProcess
-SimpleNoiseProcess
-```
-
 ## Configuration
 
 ### Rejection Sampling with Memory (RSWM)
@@ -83,8 +68,6 @@ DiffEqNoiseProcess.gbm_bridge!
 ### Compound Poisson Specific
 
 ```@docs
-DiffEqNoiseProcess.CompoundPoissonProcess
-DiffEqNoiseProcess.CompoundPoissonProcess!
 DiffEqNoiseProcess.cpp_bridge
 DiffEqNoiseProcess.cpp_bridge!
 ```

--- a/docs/src/api/noise_processes.md
+++ b/docs/src/api/noise_processes.md
@@ -1,5 +1,12 @@
 # Noise Processes API
 
+## Core Types
+
+```@docs
+NoiseProcess
+SimpleNoiseProcess
+```
+
 ## Wiener Processes
 
 ### Standard Wiener Process

--- a/docs/src/noise_processes.md
+++ b/docs/src/noise_processes.md
@@ -4,30 +4,4 @@ This section describes the available `NoiseProcess` types. Note that all
 keyword arguments are splatted into the `NoiseProcess` constructor, and thus
 options like `reset` are available on the pre-built processes.
 
-```@docs
-WienerProcess
-WienerProcess!
-RealWienerProcess
-RealWienerProcess!
-OrnsteinUhlenbeckProcess
-OrnsteinUhlenbeckProcess!
-GeometricBrownianMotionProcess
-GeometricBrownianMotionProcess!
-CorrelatedWienerProcess
-CorrelatedWienerProcess!
-SimpleWienerProcess
-SimpleWienerProcess!
-CompoundPoissonProcess
-CompoundPoissonProcess!
-```
-
-## Bridges
-
-```@docs
-BrownianBridge
-BrownianBridge!
-DiffEqNoiseProcess.GeometricBrownianBridge
-DiffEqNoiseProcess.GeometricBrownianBridge!
-DiffEqNoiseProcess.CompoundPoissonBridge
-DiffEqNoiseProcess.CompoundPoissonBridge!
-```
+See the [Noise Processes API](@ref) for constructors and bridge functions.

--- a/src/types.jl
+++ b/src/types.jl
@@ -506,7 +506,7 @@ plot!(sol2)
 plot!(sol3)
 ```
 
-![noise_process](assets/noise_process.png)
+![noise_process](../assets/noise_process.png)
 
 In this plot, `sol2` covers up `sol1` because they hit essentially the same
 values. You can see that `sol3` is similar to the others, because it's
@@ -520,7 +520,7 @@ plot!(sol2.W)
 plot!(sol3.W)
 ```
 
-![coupled_wiener](assets/coupled_wiener.png)
+![coupled_wiener](../assets/coupled_wiener.png)
 
 the coupled Wiener processes coincide at every other time point, and the intermediate
 timepoints were calculated according to a Brownian bridge.
@@ -546,7 +546,7 @@ plot(sol4)
 plot!(sol5)
 ```
 
-![SRI_SRIW1_diff](assets/SRI_SRIW1_diff.png)
+![SRI_SRIW1_diff](../assets/SRI_SRIW1_diff.png)
 """
 mutable struct NoiseWrapper{T, N, Tt, T2, T3, T4, ZType, inplace} <:
     AbstractNoiseProcess{T, N, Vector{T2}, inplace}


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

The strict SciMLTesting 2.4 setup and extension loading have already landed on `master` in #302 and #306. This rebases the remaining work onto current `master` and limits the PR to documentation and docstring corrections:

- consolidate duplicate `@docs` entries onto the canonical noise-process API page;
- stop rendering the dependency-owned `SciMLBase.AbstractNoiseProcess` entry;
- correct the three `NoiseWrapper` docstring image paths at the original definition;
- make Documenter errors and doctest failures fatal instead of warning-only or disabled.

Local validation:

- Julia release `Pkg.test()`: passed, including 1,282,612 RSwM correctness assertions and 92 bridge checks;
- Julia LTS `Pkg.test()`: passed with the same assertion totals;
- Julia release strict QA: 14 passed, 4 existing configured broken checks;
- Julia LTS strict QA: 13 passed, 3 existing configured broken checks;
- Julia release and LTS docs builds with doctests: passed;
- Runic over every tracked Julia file: passed;
- `git diff --check`: passed.
