### PR TITLE
QA: load weakdeps so package extensions are actually scanned

### DIFF
--- a/ext/DiffEqNoiseProcessOptimExt.jl
+++ b/ext/DiffEqNoiseProcessOptimExt.jl
@@ -1,6 +1,5 @@
 module DiffEqNoiseProcessOptimExt
 
-using DiffEqNoiseProcess
 import DiffEqNoiseProcess: constrained_optimization_problem, linear_interpolation_wedges
 import Optim
 

--- a/ext/DiffEqNoiseProcessReverseDiffExt.jl
+++ b/ext/DiffEqNoiseProcessReverseDiffExt.jl
@@ -1,10 +1,12 @@
 module DiffEqNoiseProcessReverseDiffExt
 
-using DiffEqNoiseProcess, DiffEqBase, Random
+using DiffEqNoiseProcess: DiffEqNoiseProcess
+using Random: AbstractRNG
+using SciMLBase: value
 import ReverseDiff
 
 @inline function DiffEqNoiseProcess.wiener_randn(
-        rng::Random.AbstractRNG,
+        rng::AbstractRNG,
         proto::ReverseDiff.TrackedArray
     )
     return ReverseDiff.track(convert.(eltype(proto.value), randn(rng, size(proto))))
@@ -15,7 +17,7 @@ end
             <:ReverseDiff.TrackedReal,
         }
     )
-    return rand_vec .= ReverseDiff.track.(randn.((rng,), typeof.(DiffEqBase.value.(rand_vec))))
+    return rand_vec .= ReverseDiff.track.(randn.((rng,), typeof.(value.(rand_vec))))
 end
 @inline function DiffEqNoiseProcess.wiener_randn!(
         rng::AbstractRNG,
@@ -23,7 +25,7 @@ end
             <:ReverseDiff.TrackedReal,
         }
     )
-    return rand_vec .= ReverseDiff.track.(randn.((rng,), typeof.(DiffEqBase.value.(rand_vec))))
+    return rand_vec .= ReverseDiff.track.(randn.((rng,), typeof.(value.(rand_vec))))
 end
 
 end

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,12 +1,16 @@
 [deps]
 DiffEqNoiseProcess = "77a26b50-5914-5dd7-bc55-306e6241c503"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+Optim = "429524aa-4258-5aef-a3af-852621145aeb"
+ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 DiffEqNoiseProcess = "5"
 JET = "0.9, 0.10, 0.11, 0.12"
+Optim = "1, 2"
+ReverseDiff = "1"
 SciMLTesting = "2.4"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,5 +1,11 @@
 using SciMLTesting, DiffEqNoiseProcess, JET, Test
 
+# ExplicitImports can only scan an extension whose module actually exists, and an
+# extension module is only created once its trigger package is loaded. Loading the
+# weakdeps here is what puts DiffEqNoiseProcessOptimExt and
+# DiffEqNoiseProcessReverseDiffExt under the QA checks at all.
+using Optim, ReverseDiff
+
 run_qa(
     DiffEqNoiseProcess;
     # ambiguities / deps_compat / piracies are genuine findings tracked in
@@ -29,6 +35,11 @@ run_qa(
             ignore = (
                 Symbol("@.."),   # FastBroadcast (via DiffEqBase), not public
                 :DEIntegrator,   # SciMLBase (via DiffEqBase), not public
+                # An extension is a separate `Base.moduleroot` from the package it
+                # extends, so pulling in the package's own unexported functions --
+                # the whole point of an extension -- reads as a non-public import.
+                :constrained_optimization_problem, # DiffEqNoiseProcess (Optim ext)
+                :linear_interpolation_wedges,      # DiffEqNoiseProcess (Optim ext)
             ),
         ),
         # __solve / has_reinit are SciMLBase names re-exported by DiffEqBase and
@@ -43,6 +54,19 @@ run_qa(
                 :__solve,               # DiffEqBase (SciMLBase name extended via DiffEqBase)
                 :has_reinit,            # DiffEqBase (SciMLBase name extended via DiffEqBase)
                 :copyat_or_push!,       # ResettableStacks, not public
+                # Same extension/moduleroot caveat as above: the ReverseDiff ext adds
+                # methods to DiffEqNoiseProcess's own unexported functions.
+                :wiener_randn,          # DiffEqNoiseProcess (ReverseDiff ext)
+                :wiener_randn!,         # DiffEqNoiseProcess (ReverseDiff ext)
+                # ReverseDiff declares nothing public; its tracked types and `track`
+                # are the only way to write a ReverseDiff rule.
+                :TrackedArray,          # ReverseDiff, not public
+                :TrackedReal,           # ReverseDiff, not public
+                :track,                 # ReverseDiff, not public
+                # Optim owns its own `minimum` (it does not extend Base's) and never
+                # declares it public, but it is the documented accessor for the
+                # objective value of an optimization result.
+                :minimum,               # Optim, not public
             ),
         ),
     ),


### PR DESCRIPTION
**Please ignore this PR until reviewed by @ChrisRackauckas.**

## Problem

`SciMLTesting.run_qa` runs ExplicitImports' checks on the package module.
ExplicitImports *does* know about extensions -- it reads the `[extensions]` table
out of `Project.toml` -- but it skips any extension whose module does not exist:

```julia
ext_mod = Base.get_extension(mod, Symbol(ext))
ext_mod === nothing && continue
```

An extension module only comes into existence once its trigger weakdep is loaded,
and `test/qa/Project.toml` loaded no weakdeps. So **neither extension in this
package was being scanned at all.**

Verified on the unmodified base branch (probe run from `test/qa`):

```
DiffEqNoiseProcessOptimExt => nothing
DiffEqNoiseProcessReverseDiffExt => nothing
SCANNED: DiffEqNoiseProcess
```

This is a real gap, not incidental coverage -- neither weakdep is pulled in
transitively by another QA dep, so `using Optim` / `using ReverseDiff` in that
environment fails outright on `master`.

## Change

Add `Optim` and `ReverseDiff` to `test/qa/Project.toml` (same UUIDs as the root
`[weakdeps]`, compat mirroring the root bounds) and `using` them in
`test/qa/qa.jl`. After the change:

```
DiffEqNoiseProcessOptimExt => DiffEqNoiseProcessOptimExt
DiffEqNoiseProcessReverseDiffExt => DiffEqNoiseProcessReverseDiffExt
SCANNED: DiffEqNoiseProcessOptimExt
SCANNED: DiffEqNoiseProcess
SCANNED: DiffEqNoiseProcessReverseDiffExt
```

Coverage is complete: both weakdeps are pure Julia and resolve cleanly, so no
extension is left unscanned.

## Findings fixed in the extension source (not ignored)

`no_implicit_imports`

* `DiffEqNoiseProcessOptimExt` had a redundant bare `using DiffEqNoiseProcess`
  alongside the `import DiffEqNoiseProcess: ...` line that actually does the work.
  Removed.
* `DiffEqNoiseProcessReverseDiffExt` relied on `DiffEqBase`, `DiffEqNoiseProcess`,
  `Random` and `AbstractRNG` implicitly. Now `using DiffEqNoiseProcess: DiffEqNoiseProcess`
  and `using Random: AbstractRNG`.

`all_qualified_accesses_via_owners`

* `DiffEqBase.value` is owned by `SciMLBase` (`Base.which(DiffEqBase, :value) === SciMLBase`);
  DiffEqBase merely re-exports it. Switched to `using SciMLBase: value`, which is
  both the owner and public (`:value in names(SciMLBase)`). `SciMLBase` is already
  a hard dependency, so this needs no new `[weakdeps]`/`[compat]` entry. `using DiffEqBase`
  is now unnecessary in this extension and was dropped.

## Ignore entries added, and why each is irreducible

`all_explicit_imports_are_public`

* `:constrained_optimization_problem`, `:linear_interpolation_wedges` -- these are
  `DiffEqNoiseProcess`'s own unexported functions, imported by its own Optim
  extension. An extension has a distinct `Base.moduleroot` from the package it
  extends, so ExplicitImports does not treat this as an internal access even
  though adding methods to the parent's functions is the entire purpose of an
  extension. There is no public spelling and no reason to make these public.

`all_qualified_accesses_are_public`

* `:wiener_randn`, `:wiener_randn!` -- same case as above, for the ReverseDiff
  extension.
* `:TrackedArray`, `:TrackedReal`, `:track` -- ReverseDiff declares nothing
  public (`Base.ispublic(ReverseDiff, :track) === false`, likewise for the tracked
  types). These are the only way to write a ReverseDiff rule.
* `:minimum` -- `Optim` owns its own `minimum` binding (`Base.which(Optim, :minimum) === Optim`;
  it does not extend `Base.minimum`) and never exports or declares it public, but
  it is the documented accessor for the objective value of an optimization result.

No check was disabled, and nothing was marked `@test_broken`.

## Local verification

`GROUP=QA julia --project=. -e 'using Pkg; Pkg.test()'` on this branch:

```
Test Summary: | Pass  Broken  Total     Time
QA/qa.jl      |   14       4     18  2m24.4s
     Testing DiffEqNoiseProcess tests passed
```

(The 4 broken are the pre-existing `aqua_broken` / `jet_broken` entries tracked in
https://github.com/SciML/DiffEqNoiseProcess.jl/issues/283.) For contrast, the same
command with the weakdeps added but before the source fixes and ignores gave
`10 passed, 0 failed, 4 errored, 4 broken` -- i.e. the newly-scanned extensions
did produce real findings.

Both extensions were also smoke-tested after the source changes:

* Optim ext: `BoxWedgeTail(0.0, zeros(2), box_grouping = :MinEntropy)` (default
  `sqeezing = true`, which routes through `constrained_optimization_problem`)
  builds and yields `nboxes = 2975`, matching the value asserted in
  `test/BWT_test.jl`.
* ReverseDiff ext: `wiener_randn` on a `TrackedArray` and `wiener_randn!` on an
  `Array{TrackedReal}` both return correctly-tracked values with `SciMLBase.value`
  in place of `DiffEqBase.value`.

Runic reported no changes on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Yb5kCpT5SRzTrhppKSh1n7