### PR TITLE
Fix distributional errors in the RSwM rejection path

### DIFF
--- a/src/noise_interfaces/noise_process_interface.jl
+++ b/src/noise_interfaces/noise_process_interface.jl
@@ -92,7 +92,21 @@ The function implements different variants of the RSWM algorithm:
     end
     if adaptive_alg(W) == :RSwM1
         if !isempty(W.S₁)
-            W.dt, W.dW, W.dZ = pop!(W.S₁)
+            L₁, L₂, L₃ = pop!(W.S₁)
+            W.dt = L₁
+            # copy rather than rebind: the popped tuple still points into the
+            # stack's storage, which later pushes reuse
+            if isinplace(W)
+                copyto!(W.dW, L₂)
+                if W.Z !== nothing
+                    copyto!(W.dZ, L₃)
+                end
+            else
+                W.dW = L₂
+                if W.Z !== nothing
+                    W.dZ = L₃
+                end
+            end
         else # Stack is empty
             calculate_step!(W, W.dt, u, p)
         end
@@ -128,7 +142,7 @@ The function implements different variants of the RSWM algorithm:
                 end
                 if adaptive_alg(W) == :RSwM3
                     if L₁ > W.rswm.discard_length
-                        push!(W.S₂, (L₁, L₂, L₃))
+                        ResettableStacks.copyat_or_push!(W.S₂, (L₁, L₂, L₃))
                     end
                 end
             else #Popped too far
@@ -172,28 +186,32 @@ The function implements different variants of the RSWM algorithm:
                         end
                     end
                     if W.Z == nothing
-                        push!(W.S₁, ((1 - qtmp) * L₁, L₂, nothing))
+                        ResettableStacks.copyat_or_push!(
+                            W.S₁, ((1 - qtmp) * L₁, L₂, nothing)
+                        )
                     else
-                        push!(W.S₁, ((1 - qtmp) * L₁, L₂, L₃))
+                        ResettableStacks.copyat_or_push!(
+                            W.S₁, ((1 - qtmp) * L₁, L₂, L₃)
+                        )
                     end
-                    if adaptive_alg(W) == :RSwM3 && qtmp * L₁ > W.rswm.discard_length
-                        if W.Z == nothing
-                            ResettableStacks.copyat_or_push!(
-                                W.S₂,
-                                (
-                                    qtmp * L₁, W.dWtilde,
-                                    nothing,
-                                )
-                            )
-                        else
-                            ResettableStacks.copyat_or_push!(
-                                W.S₂,
-                                (
-                                    qtmp * L₁, W.dWtilde,
-                                    W.dZtilde,
-                                )
-                            )
-                        end
+                    if length(W.S₁) > W.maxstacksize
+                        W.maxstacksize = length(W.S₁)
+                    end
+                end
+                # S₂ must decompose the whole step regardless of whether the
+                # right-hand remainder was large enough to keep on S₁.
+                if adaptive_alg(W) == :RSwM3 && qtmp * L₁ > W.rswm.discard_length
+                    if W.Z == nothing
+                        ResettableStacks.copyat_or_push!(
+                            W.S₂, (qtmp * L₁, W.dWtilde, nothing)
+                        )
+                    else
+                        ResettableStacks.copyat_or_push!(
+                            W.S₂, (qtmp * L₁, W.dWtilde, W.dZtilde)
+                        )
+                    end
+                    if length(W.S₂) > W.maxstacksize2
+                        W.maxstacksize2 = length(W.S₂)
                     end
                 end
                 break
@@ -300,18 +318,18 @@ the unused portion after bridging and recalculates fresh noise for subsequent st
     # where stored future values would have been generated with incorrect parameters
     if adaptive_alg(W) == :RSwM0
         if isinplace(W)
-            W.bridge(W.dWtilde, W, 0, W.dW, q, dtnew, u, p, W.curt, W.rng)
+            W.bridge(W.dWtilde, W, 0, W.dW, q, W.dt, u, p, W.curt, W.rng)
             if W.Z !== nothing
-                W.bridge(W.dZtilde, W, 0, W.dZ, q, dtnew, u, p, W.curt, W.rng)
+                W.bridge(W.dZtilde, W, 0, W.dZ, q, W.dt, u, p, W.curt, W.rng)
             end
             copyto!(W.dW, W.dWtilde)
             if W.Z !== nothing
                 copyto!(W.dZ, W.dZtilde)
             end
         else
-            W.dWtilde = W.bridge(W.dW, W, 0, W.dW, q, dtnew, u, p, W.curt, W.rng)
+            W.dWtilde = W.bridge(W.dW, W, 0, W.dW, q, W.dt, u, p, W.curt, W.rng)
             if W.Z !== nothing
-                W.dZtilde = W.bridge(W.dZ, W, 0, W.dZ, q, dtnew, u, p, W.curt, W.rng)
+                W.dZtilde = W.bridge(W.dZ, W, 0, W.dZ, q, W.dt, u, p, W.curt, W.rng)
             end
             W.dW = W.dWtilde
             if W.Z !== nothing
@@ -323,23 +341,29 @@ the unused portion after bridging and recalculates fresh noise for subsequent st
         return nothing
     elseif adaptive_alg(W) == :RSwM1 || adaptive_alg(W) == :RSwM2 ||
             (adaptive_alg(W) == :RSwM3 && isempty(W.S₂))
+        # The bridge spans the whole step being shrunk, so its total length is
+        # W.dt; q = dtnew/W.dt already carries where inside it the cut lands.
         if isinplace(W)
-            W.bridge(W.dWtilde, W, 0, W.dW, q, dtnew, u, p, W.curt, W.rng)
+            W.bridge(W.dWtilde, W, 0, W.dW, q, W.dt, u, p, W.curt, W.rng)
             if W.Z !== nothing
-                W.bridge(W.dZtilde, W, 0, W.dZ, q, dtnew, u, p, W.curt, W.rng)
+                W.bridge(W.dZtilde, W, 0, W.dZ, q, W.dt, u, p, W.curt, W.rng)
             end
         else
-            W.dWtilde = W.bridge(W.dW, W, 0, W.dW, q, dtnew, u, p, W.curt, W.rng)
+            W.dWtilde = W.bridge(W.dW, W, 0, W.dW, q, W.dt, u, p, W.curt, W.rng)
             if W.Z !== nothing
-                W.dZtilde = W.bridge(W.dZ, W, 0, W.dZ, q, dtnew, u, p, W.curt, W.rng)
+                W.dZtilde = W.bridge(W.dZ, W, 0, W.dZ, q, W.dt, u, p, W.curt, W.rng)
             end
         end
         cutLength = W.dt - dtnew
         if cutLength > W.rswm.discard_length
             if W.Z == nothing
-                push!(W.S₁, (cutLength, W.dW - W.dWtilde, nothing))
+                ResettableStacks.copyat_or_push!(
+                    W.S₁, (cutLength, W.dW - W.dWtilde, nothing)
+                )
             else
-                push!(W.S₁, (cutLength, W.dW - W.dWtilde, W.dZ - W.dZtilde))
+                ResettableStacks.copyat_or_push!(
+                    W.S₁, (cutLength, W.dW - W.dWtilde, W.dZ - W.dZtilde)
+                )
             end
         end
         if length(W.S₁) > W.maxstacksize
@@ -349,13 +373,15 @@ the unused portion after bridging and recalculates fresh noise for subsequent st
             cutLength = dtnew
             if cutLength > W.rswm.discard_length
                 if W.Z == nothing
-                    push!(W.S₂, (cutLength, W.dWtilde, nothing))
+                    ResettableStacks.copyat_or_push!(W.S₂, (cutLength, W.dWtilde, nothing))
                 else
-                    push!(W.S₂, (cutLength, W.dWtilde, W.dZtilde))
+                    ResettableStacks.copyat_or_push!(
+                        W.S₂, (cutLength, W.dWtilde, W.dZtilde)
+                    )
                 end
             end
             if length(W.S₂) > W.maxstacksize2
-                W.maxstacksize = length(W.S₂)
+                W.maxstacksize2 = length(W.S₂)
             end
         end
         if isinplace(W)
@@ -374,7 +400,7 @@ the unused portion after bridging and recalculates fresh noise for subsequent st
             dttmp = zero(W.dt)
             W.dWtmp = zero(W.dW)
             if W.Z !== nothing
-                W.dZtmp = zero(W.dZtmp)
+                W.dZtmp = zero(W.dZ)
             end
         else
             dttmp = zero(W.dt)
@@ -386,6 +412,7 @@ the unused portion after bridging and recalculates fresh noise for subsequent st
         if length(W.S₂) > W.maxstacksize2
             W.maxstacksize2 = length(W.S₂)
         end
+        bridged = false
         while !isempty(W.S₂)
             L₁, L₂, L₃ = pop!(W.S₂)
             dttmp += L₁
@@ -401,7 +428,10 @@ the unused portion after bridging and recalculates fresh noise for subsequent st
                 end
             end
             if dttmp < (1 - q) * W.dt #while the backwards movement is less than chop off
-                push!(W.S₁, (L₁, L₂, L₃))
+                ResettableStacks.copyat_or_push!(W.S₁, (L₁, L₂, L₃))
+                if length(W.S₁) > W.maxstacksize
+                    W.maxstacksize = length(W.S₁)
+                end
             else
                 dtM = (q - 1) * W.dt + dttmp
                 qM = dtM / L₁
@@ -416,12 +446,18 @@ the unused portion after bridging and recalculates fresh noise for subsequent st
                         W.dZtilde = W.bridge(W.dZ, W, 0, L₃, qM, L₁, u, p, W.curt, W.rng)
                     end
                 end
+                # The right part of this chunk must reach S₁ before S₂ reuses the
+                # slot L₂ was popped from.
                 cutLength = L₁ - dtM
                 if cutLength > W.rswm.discard_length
                     if W.Z == nothing
-                        push!(W.S₁, (cutLength, L₂ - W.dWtilde, nothing))
+                        ResettableStacks.copyat_or_push!(
+                            W.S₁, (cutLength, L₂ - W.dWtilde, nothing)
+                        )
                     else
-                        push!(W.S₁, (cutLength, L₂ - W.dWtilde, L₃ - W.dZtilde))
+                        ResettableStacks.copyat_or_push!(
+                            W.S₁, (cutLength, L₂ - W.dWtilde, L₃ - W.dZtilde)
+                        )
                     end
                 end
                 if length(W.S₁) > W.maxstacksize
@@ -430,18 +466,83 @@ the unused portion after bridging and recalculates fresh noise for subsequent st
                 cutLength = dtM
                 if cutLength > W.rswm.discard_length
                     if W.Z == nothing
-                        push!(W.S₂, (cutLength, W.dWtilde, nothing))
+                        ResettableStacks.copyat_or_push!(
+                            W.S₂, (cutLength, W.dWtilde, nothing)
+                        )
                     else
-                        push!(W.S₂, (cutLength, W.dWtilde, W.dZtilde))
+                        ResettableStacks.copyat_or_push!(
+                            W.S₂, (cutLength, W.dWtilde, W.dZtilde)
+                        )
                     end
                 end
                 if length(W.S₂) > W.maxstacksize2
-                    W.maxstacksize = length(W.S₂)
+                    W.maxstacksize2 = length(W.S₂)
                 end
+                bridged = true
                 break
             end
         end # end while
-        if isinplace(W)
+        if !bridged
+            # S₂ did not account for the whole step (chunks below discard_length are
+            # dropped), so the head [curt, curt+dtK] is still undecomposed. Bridge it
+            # directly, exactly as the S₂-empty branch does for the full step.
+            dtK = W.dt - dttmp
+            qK = dtnew / dtK
+            if isinplace(W)
+                @.. W.dWtmp = W.dW - W.dWtmp
+                W.bridge(W.dWtilde, W, 0, W.dWtmp, qK, dtK, u, p, W.curt, W.rng)
+                if W.Z !== nothing
+                    @.. W.dZtmp = W.dZ - W.dZtmp
+                    W.bridge(W.dZtilde, W, 0, W.dZtmp, qK, dtK, u, p, W.curt, W.rng)
+                end
+            else
+                W.dWtmp = W.dW - W.dWtmp
+                W.dWtilde = W.bridge(W.dW, W, 0, W.dWtmp, qK, dtK, u, p, W.curt, W.rng)
+                if W.Z !== nothing
+                    W.dZtmp = W.dZ - W.dZtmp
+                    W.dZtilde = W.bridge(W.dZ, W, 0, W.dZtmp, qK, dtK, u, p, W.curt, W.rng)
+                end
+            end
+            cutLength = dtK - dtnew
+            if cutLength > W.rswm.discard_length
+                if W.Z == nothing
+                    ResettableStacks.copyat_or_push!(
+                        W.S₁, (cutLength, W.dWtmp - W.dWtilde, nothing)
+                    )
+                else
+                    ResettableStacks.copyat_or_push!(
+                        W.S₁, (cutLength, W.dWtmp - W.dWtilde, W.dZtmp - W.dZtilde)
+                    )
+                end
+            end
+            if length(W.S₁) > W.maxstacksize
+                W.maxstacksize = length(W.S₁)
+            end
+            if dtnew > W.rswm.discard_length
+                if W.Z == nothing
+                    ResettableStacks.copyat_or_push!(W.S₂, (dtnew, W.dWtilde, nothing))
+                else
+                    ResettableStacks.copyat_or_push!(
+                        W.S₂, (dtnew, W.dWtilde, W.dZtilde)
+                    )
+                end
+            end
+            if length(W.S₂) > W.maxstacksize2
+                W.maxstacksize2 = length(W.S₂)
+            end
+            # the bridged head *is* the new increment
+            if isinplace(W)
+                copyto!(W.dW, W.dWtilde)
+                if W.Z !== nothing
+                    copyto!(W.dZ, W.dZtilde)
+                end
+            else
+                W.dW = W.dWtilde
+                if W.Z !== nothing
+                    W.dZ = W.dZtilde
+                end
+            end
+        elseif isinplace(W)
             @.. W.dW += W.dWtilde - W.dWtmp
             if W.Z !== nothing
                 @.. W.dZ += W.dZtilde - W.dZtmp

--- a/test/RSwM_correctness_test.jl
+++ b/test/RSwM_correctness_test.jl
@@ -1,0 +1,155 @@
+@testset "RSwM rejection correctness" begin
+    using DiffEqNoiseProcess, Test, Random, Statistics
+
+    # A NoiseProcess driven through a FIXED accept/reject pattern must still produce
+    # a genuine Brownian path: increments over the accepted grid are independent and
+    # N(0, Δt). Because the pattern is fixed, the grid is identical across seeds, so
+    # the increments can be compared statistically.
+    #
+    # Rejection factors are expressed relative to W.dt rather than as absolute step
+    # sizes, since RSwM1's setup_next_step! overrides W.dt from the stack.
+
+    # (:reject, q) shrinks to q*W.dt; (:accept, g) proposes g*W.dt for the next step
+    function make_schedule(; nacc = 8, seed = 1, preject = 0.55)
+        rng = Xoshiro(seed)
+        ops = Tuple{Symbol, Float64}[]
+        for _ in 1:nacc
+            while rand(rng) < preject
+                push!(ops, (:reject, 0.2 + 0.7 * rand(rng)))
+            end
+            push!(ops, (:accept, 1.0 + 1.5 * rand(rng)))
+        end
+        return ops
+    end
+
+    function build(alg, iip, n, withZ, seed)
+        return if iip
+            WienerProcess!(
+                0.0, zeros(n), withZ ? zeros(n) : nothing;
+                rswm = RSWM(adaptivealg = alg), rng = Xoshiro(seed)
+            )
+        else
+            WienerProcess(
+                0.0, 0.0, withZ ? 0.0 : nothing;
+                rswm = RSWM(adaptivealg = alg), rng = Xoshiro(seed)
+            )
+        end
+    end
+
+    function run_path(ops, alg, iip, n, withZ, seed; h0 = 0.2)
+        W = build(alg, iip, n, withZ, seed)
+        calculate_step!(W, h0, nothing, nothing)
+        for (kind, f) in ops
+            kind === :accept ? accept_step!(W, f * W.dt, nothing, nothing) :
+                reject_step!(W, f * W.dt, nothing, nothing)
+        end
+        return W
+    end
+
+    @testset "single rejection has the right variance" begin
+        # Bridging a step of length h down to q*h must give an increment with
+        # variance q*h. Getting the bridge's total-interval argument wrong instead
+        # yields q*(2-q)*h.
+        M = 100_000
+        h = 1.0
+        for alg in (:RSwM0, :RSwM1, :RSwM2, :RSwM3), q in (0.25, 0.5, 0.8)
+            xs = Vector{Float64}(undef, M)
+            for m in 1:M
+                W = WienerProcess(
+                    0.0, 0.0, nothing;
+                    rswm = RSWM(adaptivealg = alg), rng = Xoshiro(m)
+                )
+                calculate_step!(W, h, nothing, nothing)
+                reject_step!(W, q * h, nothing, nothing)
+                xs[m] = W.dW
+            end
+            @test isapprox(var(xs) / (q * h), 1.0, atol = 6 * sqrt(2 / M))
+        end
+    end
+
+    @testset "accept/reject schedules stay Brownian" begin
+        M = 20_000
+        for sseed in 1:2
+            ops = make_schedule(seed = sseed)
+            for alg in (:RSwM0, :RSwM1, :RSwM2, :RSwM3),
+                    (iip, n) in ((false, 1), (true, 2)),
+                    withZ in (false, true)
+
+                ts = copy(run_path(ops, alg, iip, n, withZ, 1).t)
+                nt = length(ts)
+                d = iip ? n : 1
+                incW = zeros(M, nt - 1, d)
+                incZ = withZ ? zeros(M, nt - 1, d) : zeros(0, 0, 0)
+                for m in 1:M
+                    W = run_path(ops, alg, iip, n, withZ, 1000 + m)
+                    @test length(W.t) == nt
+                    @test maximum(abs, W.t .- ts) < 1.0e-12
+                    for i in 1:(nt - 1)
+                        incW[m, i, :] .= W.W[i + 1] .- W.W[i]
+                        withZ && (incZ[m, i, :] .= W.Z[i + 1] .- W.Z[i])
+                    end
+                end
+                dts = diff(ts)
+                for inc in (incW, incZ)
+                    isempty(inc) && continue
+                    for i in 1:(nt - 1)
+                        x = vec(@view inc[:, i, :])
+                        @test isapprox(
+                            var(x) / dts[i], 1.0,
+                            atol = 6 * sqrt(2 / (M * d))
+                        )
+                        @test abs(mean(x)) < 6 * sqrt(dts[i] / (M * d))
+                    end
+                    for i in 1:(nt - 2)
+                        c = cor(vec(@view inc[:, i, :]), vec(@view inc[:, i + 1, :]))
+                        @test abs(c) < 6 / sqrt(M * d)
+                    end
+                end
+            end
+        end
+    end
+
+    @testset "in-place stacks never alias the scratch buffers" begin
+        # ResettableStacks.push! stores by reference while copyat_or_push! copies, so
+        # pushing a scratch buffer onto a stack would let later bridges silently
+        # rewrite stored noise.
+        ops = make_schedule(seed = 3)
+        for alg in (:RSwM1, :RSwM2, :RSwM3), withZ in (false, true)
+            W = build(alg, true, 3, withZ, 7)
+            calculate_step!(W, 0.2, nothing, nothing)
+            for (kind, f) in ops
+                kind === :accept ? accept_step!(W, f * W.dt, nothing, nothing) :
+                    reject_step!(W, f * W.dt, nothing, nothing)
+                scratch = Any[W.dW, W.dWtilde, W.dWtmp, W.curW]
+                withZ && append!(scratch, Any[W.dZ, W.dZtilde, W.dZtmp, W.curZ])
+                entries = Any[]
+                for S in (W.S₁, W.S₂), el in collect(S)
+                    push!(entries, el[2])
+                    withZ && push!(entries, el[3])
+                end
+                for e in entries
+                    @test !any(b -> e === b, scratch)
+                end
+                for a in 1:length(entries), b in (a + 1):length(entries)
+                    @test !(entries[a] === entries[b])
+                end
+            end
+        end
+    end
+
+    @testset "RSwM3 S₂ decomposes the current step" begin
+        # S₂ holds the breakdown of the step currently being attempted; its lengths
+        # must add up to W.dt or a rejection walks back over the wrong interval.
+        ops = make_schedule(seed = 4)
+        for (iip, n) in ((false, 1), (true, 2))
+            W = build(:RSwM3, iip, n, true, 11)
+            calculate_step!(W, 0.2, nothing, nothing)
+            for (kind, f) in ops
+                kind === :accept ? accept_step!(W, f * W.dt, nothing, nothing) :
+                    reject_step!(W, f * W.dt, nothing, nothing)
+                s = sum(el[1] for el in collect(W.S₂); init = zero(W.dt))
+                @test isapprox(s, W.dt, atol = 1.0e-12)
+            end
+        end
+    end
+end


### PR DESCRIPTION
**Please ignore this PR until it has been reviewed by @ChrisRackauckas.**

Follow-up to the SRIW1/oval2 regression reported in
https://github.com/SciML/SciMLBenchmarks.jl/pull/1605#issuecomment-5178129135,
which bisected to #80 (`RSwM3 correctness`, v5.5.0 → v5.5.1).

I confirmed that bisect and, while checking it, found that `reject_step!` has
four independent defects — two from #80, two much older — that all make the
rejection bridge return increments with the wrong variance. The adaptive solvers
therefore run on a path that is not a Brownian motion.

### What #80 got right

Its algorithmic criticism holds. Pre-#80, the RSwM3 walk-back bridged the whole
merged interval `[curt, curt+dtK]` and ignored the sub-chunk structure still
sitting on S₂, so a *second* rejection walked back over noise the bridge had
never conditioned on. In a three-chunk example with lengths 0.5/0.1/0.4 and a
cut inside the middle chunk, the increment handed to S₁ on the next rejection has
variance 0.4667 where 0.45 is required. The replacement branch — split only the
chunk that straddles the cut — is correct, and it still passes here after the
other fixes. The problems #80 introduced were implementation-level.

### 1. Bridge interval argument (all variants; predates #80)

`WHITE_NOISE_BRIDGE(dW, W, W0, Wh, q, h, ...)` returns
`sqrt((1-q)·q·|h|)·ξ + q·Wh`, so `h` is the length of the whole interval being
bridged and `q` says where inside it the cut falls. `setup_next_step!` calls it
correctly (`bridge(..., qtmp, L₁, ...)` with `L₁` the full chunk), but
`reject_step!` passed the *post*-rejection length `dtnew` instead of `W.dt`:

```julia
W.bridge(W.dWtilde, W, 0, W.dW, q, dtnew, u, p, W.curt, W.rng)   # h should be W.dt
```

That gives `Var = q²·W.dt + q(1-q)·q·W.dt = q(2-q)·dtnew` instead of `dtnew`.
Measured against a fresh step of length 1 (100k samples):

| q | Var(dW)/dt measured | q(2-q) | correct |
|---|---|---|---|
| 0.2 | 0.3593 | 0.3600 | 1.0 |
| 0.5 | 0.7486 | 0.7500 | 1.0 |
| 0.8 | 0.9587 | 0.9600 | 1.0 |

This affects RSwM0/1/2 on every rejection and RSwM3 whenever S₂ is empty. It has
been there since the file was first added (bd5d244, May 2017).

### 2. Stack entries aliasing live scratch buffers (in-place; from #80)

`ResettableStacks.push!` stores its argument by reference, while
`copyat_or_push!` copies. #80 added `push!(W.S₂, (cutLength, W.dWtilde, ...))`,
so S₂ ended up holding the live `W.dWtilde` buffer. On the next rejection that
entry is popped as `L₂` and passed as the bridge's target:

```julia
W.bridge(W.dWtilde, W, 0, L₂, qM, L₁, ...)   # L₂ === W.dWtilde
```

`INPLACE_WHITE_NOISE_BRIDGE` fills `rand_vec` with normals *before* reading
`Wh`, so when they are the same array the target is destroyed and the result is
`(sqrt((1-q)q·h) + q)·ξ`. Worse, the alias is permanent: once a slot holds the
buffer, later `copyat_or_push!` calls into that slot copy the buffer onto
itself, so `reset!` never clears it.

Measured on an in-place process under a fixed accept/reject schedule, worst
Var(ΔW)/Δt over the accepted grid was **330** (z ≈ 7.4e4); some increments came
out exactly zero. Scalar processes are unaffected, which is why this went
unnoticed.

All stack writes now go through `copyat_or_push!`. RSwM1's
`W.dt, W.dW, W.dZ = pop!(W.S₁)` had the same problem in the other direction —
it rebound `W.dW` to stack storage — and now copies.

### 3. Stale `W.dWtilde` in the RSwM3 walk-back (from #80)

After #80 `W.dWtilde` is assigned only on the branch that splits a chunk. If the
`while !isempty(W.S₂)` loop drains without reaching it, the closing
`W.dW += W.dWtilde - W.dWtmp` mixes in whatever the buffer held from an earlier
step. The pre-#80 code computed `dtK = W.dt - dttmp` after the loop and always
bridged, so it had no such path.

It is reachable because `setup_next_step!` nested the S₂ push inside the S₁
`discard_length` test, so a chunk that fits the remaining step *exactly* is
consumed without ever being recorded on S₂ — leaving S₂ describing less than the
step it is supposed to decompose. Constructed directly on a scalar process (no
aliasing involved), the resulting increment had variance **2.299 where 0.5 is
correct**.

Fixed at the root by making the S₂ push independent of the S₁ test, plus a
fallback that bridges the undecomposed head if S₂ still comes up short (it
legitimately can, since chunks below `discard_length` are dropped).

### 4. `maxstacksize` / `maxstacksize2` (from #80)

Two sites assign `length(W.S₂)` to `maxstacksize` instead of `maxstacksize2`.
Diagnostics only.

### End-to-end: oval2

n=19, SRIW1, `abstol=2^-15`, `reltol=2^-10` — the `qmaxDetermination.jmd`
settings. Quadratic variation of the solver's own noise path must equal T for a
Brownian path; 25 trajectories, ~1900 rejections each:

| | before | after |
|---|---|---|
| RSwM1 | Success, QV/T = 0.98904 (z = −15.9) | Success, QV/T = 1.00028 (z = +0.4) |
| RSwM2 | Success, QV/T = 0.99387 (z = −8.9) | Success, QV/T = 0.99997 (z = −0.0) |
| RSwM3 | **DtLessThanMin at t = 0.0059, 0/25 solves** | Success 25/25, QV/T = 1.00063 (z = +1.0) |

RSwM3 now finishes in 3920 steps against 6575 for RSwM2 and 7004 for RSwM1, i.e.
it is again the most efficient of the three, as intended.

### Tests

`test/RSwM_correctness_test.jl` drives a process through a fixed accept/reject
pattern — so the accepted grid is identical across seeds — and checks that the
increments over that grid are independent N(0, Δt), that no stack entry aliases a
scratch buffer, and that S₂ decomposes the current step. It covers RSwM0–3,
scalar and in-place, with and without the auxiliary Z process.

On this branch: 1282612/1282612 pass. On master: 287 failures (12/12 in the
single-rejection variance check, 251 in the schedule check, 24 in the aliasing
check).

The reason none of this was caught before: `test/RSwM3_test.jl` contains no
`@test` assertions at all — it calls the functions and discards the results — and
`test/bridge_test.jl`, which #80 cited as still passing, exercises
BrownianBridge/OU-bridge processes and never reaches `reject_step!`.

`GROUP=Core` passes locally; Runic reports no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVbskh5URiXJJjAZyKneQA
