### PR TITLE
Fix RSwM stack resizing after state changes

### DIFF
--- a/src/noise_interfaces/noise_process_interface.jl
+++ b/src/noise_interfaces/noise_process_interface.jl
@@ -795,9 +795,9 @@ end
 end
 
 function resize_stack!(W::NoiseProcess, i)
-    for j in eachindex(W.S₂.data)
-        resize!(W.S₂.data[j][2], i)
-        W.S₂.data[j][3] !== nothing && resize!(W.S₂.data[j][3], i)
+    for stack in (W.S₁, W.S₂), j in eachindex(stack.data)
+        resize!(stack.data[j][2], i)
+        stack.data[j][3] !== nothing && resize!(stack.data[j][3], i)
     end
     return nothing
 end

--- a/test/RSwM_correctness_test.jl
+++ b/test/RSwM_correctness_test.jl
@@ -10,11 +10,11 @@
     # sizes, since RSwM1's setup_next_step! overrides W.dt from the stack.
 
     # (:reject, q) shrinks to q*W.dt; (:accept, g) proposes g*W.dt for the next step
-    function make_schedule(; nacc = 8, seed = 1, preject = 0.55)
+    function make_schedule(; nacc = 8, seed = 1, rejection_probability = 0.55)
         rng = Xoshiro(seed)
         ops = Tuple{Symbol, Float64}[]
         for _ in 1:nacc
-            while rand(rng) < preject
+            while rand(rng) < rejection_probability
                 push!(ops, (:reject, 0.2 + 0.7 * rand(rng)))
             end
             push!(ops, (:accept, 1.0 + 1.5 * rand(rng)))
@@ -134,6 +134,27 @@
                     @test !(entries[a] === entries[b])
                 end
             end
+        end
+    end
+
+    @testset "cached stack entries resize before reuse" begin
+        W = build(:RSwM3, true, 1, true, 7)
+        calculate_step!(W, 0.2, nothing, nothing)
+        reject_step!(W, 0.1, nothing, nothing)
+        @test length(W.S₁) == length(W.S₂) == 1
+        pop!(W.S₁)
+        pop!(W.S₂)
+
+        for field in (:dW, :dWtilde, :dWtmp, :curW, :dZ, :dZtilde, :dZtmp, :curZ)
+            resize!(getproperty(W, field), 2)
+        end
+
+        DiffEqNoiseProcess.resize_stack!(W, 2)
+        calculate_step!(W, 0.2, nothing, nothing)
+        reject_step!(W, 0.1, nothing, nothing)
+
+        for stack in (W.S₁, W.S₂), entry in stack, noise in (entry[2], entry[3])
+            @test length(noise) == 2
         end
     end
 


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary
- resize cached backing entries in both RSwM stacks when the noise state changes dimension
- correct the `preject` typo detected by the clean-default typos job
- exercise reuse of cached stack entries after a state resize

## Baseline investigation
Both failures reproduce from a clean worktree at `origin/master` `d6cce6affed8bd7c49b0817ed559a8d8a940a72f`, the merge commit for #303. Both bisect to `eb99e14dea80c07e8c87b41aae8a9319ebb904cb` (#307), rather than to #303 itself.

The OrdinaryDiffEq `Interface3` failure occurred because inactive `S1` backing entries retained the old state dimension. Reusing one through `copyat_or_push!` then broadcast a resized sample into stale storage.

## Local validation
- `typos --config .typos.toml`
- repository-wide Runic: `julia +release --project=.runic_env -m Runic --check --diff .`
- `GROUP=Core` full package tests on Julia 1.12.6 and 1.10.11
- focused RSwM correctness test on Julia 1.12.6 and 1.10.11: 1,282,617 passed
- QA on Julia 1.12.6: 14 passed, 4 preconfigured broken
- QA on Julia 1.10.11: 13 passed, 3 preconfigured broken
- OrdinaryDiffEq `b9889d3ae234f527ba00856b90d6fc9dd674298b` exact `GROUP=Interface3` rerun passed the original `Cache Tests` failure and subsequent testsets; the remaining group was still running when this draft was opened
- all 50 downstream `[sources]` entries preserved; tracked project files unchanged