### PR TITLE
Set DiffEqNoiseProcess version to 5.34.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqNoiseProcess"
 uuid = "77a26b50-5914-5dd7-bc55-306e6241c503"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "5.34.0"
+version = "5.34.1"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Correct the package version declarations to the first sequential patch or minor release after General's latest non-yanked versions. The default branch contains source changes, but this PR is limited to release metadata and internal compat needed by the sequential versions.

| Package | General | Branch before | Proposed | Bump |
|---|---:|---:|---:|---|
| DiffEqNoiseProcess | 5.34.0 | 5.34.0 | 5.34.1 | patch |

## Verification

- `GROUP=QA /home/crackauc/.juliaup/bin/julia +release --project=. -e 'using Pkg; Pkg.test()'` — passed. `Test Summary: | Pass  Broken  Total     Time / QA/qa.jl      |   14       4     18  2m41.4s / Testing DiffEqNoiseProcess tests passed`
- `/home/crackauc/.juliaup/bin/julia +release --project=. -e 'using Pkg; Pkg.test()'` — passed. `Test Summary:                      | Pass  Total  Time / Core/simple_noise_bigfloat_test.jl |    6      6  1.0s / Test Summary:         | Pass  Total  Time / Core/two_processes.jl |    8      8  1.3s / Testing DiffEqNoiseProcess tests passed`
- `/home/crackauc/.juliaup/bin/julia +release --startup-file=no -m Runic --check .` — passed.
- `typos --force-exclude Project.toml` — passed.
- `git diff --check` — passed.

The docs build was not run because this diff changes no docstrings, documentation, or public API. GPU and downstream jobs were not run locally.

## Registration

After this PR is merged, register each package separately from a commit on the default branch:

- DiffEqNoiseProcess: `@JuliaRegistrator register`