### PR TITLE
Raise Cubature extras floor to 1.5.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -30,7 +30,7 @@ DiffEqNoiseProcessReverseDiffExt = "ReverseDiff"
 
 [compat]
 CommonSolve = "0.2.6"
-Cubature = "1"
+Cubature = "1.5.1"
 DiffEqBase = "7"
 Distributions = "0.25"
 GPUArraysCore = "0.1, 0.2"


### PR DESCRIPTION
Please ignore this PR until it has been reviewed by @ChrisRackauckas.

Raise Cubature extras floor from 1 to 1.5.1.

Declared `Cubature = "1"` still allows 1.3.1 (BinDeps/Compat unsat with current SciMLBase 3) and 1.5.0 (build requires BinaryProvider, which is gone). 1.5.1 is the first jll release.

### Fail before
Isolated depot, Julia 1.10.11, `Pkg.develop` live DiffEqNoiseProcess + add Cubature:

Cubature 1.3.1:
```
FAIL Unsatisfiable requirements detected for package NonlinearSolveBase
 restricted by compatibility requirements with Compat to versions: uninstalled — no versions left
 Compat restricted by compatibility requirements with BinDeps to versions: 1.0.0-2.2.1
```

Cubature 1.5.0:
```
FAIL Error building `Cubature`:
 ArgumentError: Package BinaryProvider not found in current path.
 in expression starting at .../Cubature/NwQxL/deps/build.jl:1
```

### Pass after
Cubature 1.5.1:
```
RESOLVE_OK
LOAD_OK Cubature
```

1.4.1 resolves and loads, but 1.5.0 remains in the `1` / `1.4.1+` range and is unloadable. First working registered version that also excludes the 1.5.0 BinaryProvider hole is 1.5.1.

StaticArraysCore is already 1.4.2 via https://github.com/SciML/DiffEqNoiseProcess.jl/pull/312.

Not verified: full test suite.
