### PR TITLE
docs: audit public noise process interfaces

### DIFF
--- a/docs/src/api/interface.md
+++ b/docs/src/api/interface.md
@@ -2,6 +2,52 @@
 
 This page documents the interface functions for working with noise processes.
 
+## Process Contract
+
+All noise objects in this package are subtypes of
+[`SciMLBase.AbstractNoiseProcess`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Solutions/#SciMLBase.AbstractNoiseProcess).
+The four type parameters are the scalar element type, array rank, saved-value
+array type, and the `isinplace` mutation convention. A concrete process must
+also behave like an `AbstractDiffEqArray`: saved values are indexed through the
+usual array interface, and callable processes evaluate `(W, Z)` at a time.
+
+The callable forms are:
+
+```julia
+W(t)                    # returns (primary_value, auxiliary_value)
+W(u, p, t)              # state- and parameter-aware form
+W(out1, out2, u, p, t)  # in-place form when isinplace(W) is true
+```
+
+When no auxiliary process exists, the second returned value is `nothing`. The
+in-place form writes into `out1` and, when applicable, `out2`; it must not
+replace those caller-owned buffers.
+
+## Solver Lifecycle
+
+SDE and noise solvers use the exported lifecycle functions in this order:
+
+1. `setup_next_step!(W, u, p)` prepares the pending increment for `W.dt`.
+2. `calculate_step!(W, dt, u, p)` recomputes a pending increment without
+   committing it.
+3. `accept_step!(W, dt, u, p, setup_next)` commits the pending increment once
+   and optionally prepares the next one.
+4. `reject_step!(W, dtnew, u, p)` replaces a rejected increment while preserving
+   its conditional distribution. A process that cannot support rejection must
+   raise an explicit error; it must not silently reuse the old increment.
+5. `save_noise!(W)` records the current point for history-backed processes.
+
+The `u` and `p` arguments are `nothing` for state-independent noise. A process
+with state-dependent callbacks must forward them unchanged. Implementations
+must keep primary and auxiliary state synchronized. `accept_step!`,
+`reject_step!`, `setup_next_step!`, and `save_noise!` return `nothing`;
+`calculate_step!` may additionally return the selected step width for
+grid-backed processes, but callers should use the process state.
+
+The step functions are developer-facing extension points for solver packages;
+the process's stack, cache, and scratch-buffer fields are not part of this
+contract. Use the lifecycle functions rather than mutating those fields.
+
 ## Step Management
 
 ```@docs
@@ -21,9 +67,12 @@ RSWM
 adaptive_alg
 ```
 
-## Internal Functions
+## Developer Callback Helpers
 
-These functions are used internally by the noise process implementations:
+The following callback helpers are documented for package developers who need to
+understand or compose the built-in process implementations. They are not the
+stable user-facing process API and are not exported. New solver code should use
+the lifecycle functions above.
 
 ### Distribution Functions
 

--- a/src/DiffEqNoiseProcess.jl
+++ b/src/DiffEqNoiseProcess.jl
@@ -22,8 +22,6 @@ import QuadGK
 
 import GPUArraysCore
 
-using Markdown: Markdown, @doc_str
-
 using DiffEqBase: @..
 
 using Base: deleteat!, convert, copyto!

--- a/src/bridges.jl
+++ b/src/bridges.jl
@@ -1,14 +1,24 @@
-@doc doc"""
-A `BrownianBridge` process is a Wiener process with a pre-defined start and end
-value. This process is distribution exact and back be back interpolated exactly
-as well. The constructor is:
+"""
+    BrownianBridge(t0, tend, W0, Wend, Z0 = nothing, Zend = nothing; kwargs...)
+
+Construct a Wiener process conditioned on its values at `t0` and `tend`.
+The process is distribution exact and can be interpolated between the endpoints.
 
 ```julia
-BrownianBridge(t0,tend,W0,Wend,Z0=nothing,Zend=nothing;kwargs...)
-BrownianBridge!(t0,tend,W0,Wend,Z0=nothing,Zend=nothing;kwargs...)
+bridge = BrownianBridge(0.0, 1.0, 0.0, 1.0)
+bridge(0.5)
 ```
 
-where `W(t0)=W₀`, `W(tend)=Wend`, and likewise for the `Z` process if defined.
+# Arguments
+- `t0`, `tend`: Start and end times.
+- `W0`, `Wend`: Process values at the two endpoints.
+- `Z0`, `Zend`: Optional endpoint values for the auxiliary process.
+
+# Keywords
+Additional keywords are forwarded to [`WienerProcess`](@ref).
+
+# Returns
+A `NoiseProcess` initialized with the endpoint increment in its RSwM stack.
 """
 function BrownianBridge(t0, tend, W0, Wend, Z0 = nothing, Zend = nothing; kwargs...)
     W = WienerProcess(t0, W0, Z0; kwargs...)
@@ -24,17 +34,28 @@ function BrownianBridge(t0, tend, W0, Wend, Z0 = nothing, Zend = nothing; kwargs
     return W
 end
 
-@doc doc"""
-A `BrownianBridge` process is a Wiener process with a pre-defined start and end
-value. This process is distribution exact and back be back interpolated exactly
-as well. The constructor is:
+"""
+    BrownianBridge!(t0, tend, W0, Wend, Z0 = nothing, Zend = nothing; kwargs...)
+
+Construct the in-place variant of [`BrownianBridge`](@ref). The endpoint arrays
+are modified when their increments are formed, so pass copies when the original
+endpoint values must be preserved.
 
 ```julia
-BrownianBridge(t0,tend,W0,Wend,Z0=nothing,Zend=nothing;kwargs...)
-BrownianBridge!(t0,tend,W0,Wend,Z0=nothing,Zend=nothing;kwargs...)
+bridge = BrownianBridge!(0.0, 1.0, zeros(2), ones(2))
+bridge(0.5)
 ```
 
-where `W(t0)=W₀`, `W(tend)=Wend`, and likewise for the `Z` process if defined.
+# Arguments
+- `t0`, `tend`: Start and end times.
+- `W0`, `Wend`: Array-valued endpoint values.
+- `Z0`, `Zend`: Optional auxiliary endpoint values.
+
+# Keywords
+Additional keywords are forwarded to [`WienerProcess!`](@ref).
+
+# Returns
+A `NoiseProcess` with `isinplace(W) == true`.
 """
 function BrownianBridge!(t0, tend, W0, Wh, Z0 = nothing, Zh = nothing; kwargs...)
     W = WienerProcess!(t0, W0, Z0; kwargs...)
@@ -50,8 +71,12 @@ function BrownianBridge!(t0, tend, W0, Wh, Z0 = nothing, Zh = nothing; kwargs...
     return W
 end
 
-@doc doc"""
-A `GeometricBrownianBridge` is a geometric Brownian motion process with pre-defined start and end values.
+"""
+    GeometricBrownianBridge(μ, σ, t0, tend, W0, Wend,
+        Z0 = nothing, Zend = nothing; kwargs...)
+
+A `GeometricBrownianBridge` is a geometric Brownian motion process with
+pre-defined start and end values.
 
 This creates a GBM process that is conditioned to pass through specific values at the beginning and end of the time interval,
 useful for financial modeling where asset prices must match observed values.
@@ -67,7 +92,7 @@ useful for financial modeling where asset prices must match observed values.
 
 # Examples
 ```julia
-# Stock price bridge from $100 to $110 over 1 year
+# Stock price bridge from \$100 to \$110 over 1 year
 bridge = GeometricBrownianBridge(0.05, 0.2, 0.0, 1.0, 100.0, 110.0)
 ```
 """
@@ -88,10 +113,24 @@ function GeometricBrownianBridge(
     return W
 end
 
-@doc doc"""
-In-place version of `GeometricBrownianBridge`.
+"""
+    GeometricBrownianBridge!(μ, σ, t0, tend, W0, Wend,
+        Z0 = nothing, Zend = nothing; kwargs...)
 
-See `GeometricBrownianBridge` for details.
+In-place version of [`GeometricBrownianBridge`](@ref). It conditions an
+in-place geometric Brownian process on the supplied endpoints.
+
+# Arguments
+- `μ`, `σ`: Drift and diffusion coefficients.
+- `t0`, `tend`: Start and end times.
+- `W0`, `Wend`: Array-valued endpoint values.
+- `Z0`, `Zend`: Optional auxiliary endpoint values.
+
+# Keywords
+Additional keywords are forwarded to `GeometricBrownianMotionProcess!`.
+
+# Returns
+A `NoiseProcess` with `isinplace(W) == true`.
 """
 function GeometricBrownianBridge!(
         μ, σ, t0, tend, W0, Wh, Z0 = nothing, Zh = nothing;
@@ -110,8 +149,12 @@ function GeometricBrownianBridge!(
     return W
 end
 
-@doc doc"""
-A `CompoundPoissonBridge` is a compound Poisson process with pre-defined start and end values.
+"""
+    CompoundPoissonBridge(rate, t0, tend, W0, Wend;
+        rswm = RSWM(adaptivealg = :RSwM0), kwargs...)
+
+A `CompoundPoissonBridge` is a compound Poisson process with pre-defined start
+and end values.
 
 This creates a jump process that is conditioned to have specific values at the beginning and end of the time interval.
 The jumps are distributed to satisfy the endpoint constraint.
@@ -138,10 +181,24 @@ function CompoundPoissonBridge(rate, t0, tend, W0, Wend; rswm = RSWM(), kwargs..
     return W
 end
 
-@doc doc"""
-In-place version of `CompoundPoissonBridge`.
+"""
+    CompoundPoissonBridge!(rate, t0, tend, W0, Wend;
+        rswm = RSWM(adaptivealg = :RSwM0), kwargs...)
 
-See `CompoundPoissonBridge` for details.
+In-place version of [`CompoundPoissonBridge`](@ref).
+
+# Arguments
+- `rate`: Constant rate or `rate(u, p, t)` function.
+- `t0`, `tend`: Start and end times.
+- `W0`, `Wend`: Endpoint values; array endpoints are updated in-place.
+
+# Keywords
+- `rswm`: RSwM configuration. The default `:RSwM0` is appropriate for
+  state-dependent rates.
+- Additional keywords are forwarded to `CompoundPoissonProcess!`.
+
+# Returns
+A `NoiseProcess` with `isinplace(W) == true`.
 """
 function CompoundPoissonBridge!(rate, t0, tend, W0, Wh; rswm = RSWM(), kwargs...)
     W = CompoundPoissonProcess!(rate, t0, W0; rswm = rswm, kwargs...)
@@ -152,8 +209,12 @@ function CompoundPoissonBridge!(rate, t0, tend, W0, Wh; rswm = RSWM(), kwargs...
     return W
 end
 
-@doc doc"""
-An `OrnsteinUhlenbeckBridge` is an Ornstein-Uhlenbeck process with pre-defined start and end values.
+"""
+    OrnsteinUhlenbeckBridge(Θ, μ, σ, t0, tend, W0, Wend,
+        Z0 = nothing; kwargs...)
+
+An `OrnsteinUhlenbeckBridge` is an Ornstein-Uhlenbeck process with pre-defined
+start and end values.
 
 This creates a mean-reverting process that is conditioned to pass through specific values at the beginning
 and end of the time interval.
@@ -183,10 +244,24 @@ function OrnsteinUhlenbeckBridge(Θ, μ, σ, t0, tend, W0, Wend, Z0 = nothing; k
     return ou
 end
 
-@doc doc"""
-In-place version of `OrnsteinUhlenbeckBridge`.
+"""
+    OrnsteinUhlenbeckBridge!(Θ, μ, σ, t0, tend, W0, Wend,
+        Z0 = nothing; kwargs...)
 
-See `OrnsteinUhlenbeckBridge` for details.
+In-place version of [`OrnsteinUhlenbeckBridge`](@ref). It conditions an
+in-place exact OU process on the supplied endpoints.
+
+# Arguments
+- `Θ`, `μ`, `σ`: Mean-reversion rate, long-term mean, and diffusion coefficient.
+- `t0`, `tend`: Start and end times.
+- `W0`, `Wend`: Array-valued endpoint values.
+- `Z0`: Optional auxiliary endpoint value.
+
+# Keywords
+Additional keywords are forwarded to `OrnsteinUhlenbeckProcess!`.
+
+# Returns
+A `NoiseProcess` with `isinplace(W) == true`.
 """
 function OrnsteinUhlenbeckBridge!(Θ, μ, σ, t0, tend, W0, Wend, Z0 = nothing; kwargs...)
     ou = OrnsteinUhlenbeckProcess!(Θ, μ, σ, t0, W0, Z0; kwargs...)

--- a/src/correlated_noisefunc.jl
+++ b/src/correlated_noisefunc.jl
@@ -14,16 +14,28 @@ function construct_correlated_noisefunc(Γ)
     return dist, bridge
 end
 
-@doc doc"""
-One can define a `CorrelatedWienerProcess` which is a Wiener process with
-correlations between the Wiener processes. The constructor is:
+"""
+    CorrelatedWienerProcess(Γ, t0, W0, Z0 = nothing; rng = Random.default_rng())
+
+Construct an out-of-place Wiener process with constant covariance matrix `Γ`.
+The covariance is factored once and applied to independent normal increments.
 
 ```julia
-CorrelatedWienerProcess(Γ,t0,W0,Z0=nothing;kwargs...)
-CorrelatedWienerProcess!(Γ,t0,W0,Z0=nothing;kwargs...)
+Γ = [1.0 0.2; 0.2 1.0]
+W = CorrelatedWienerProcess(Γ, 0.0, zeros(2))
 ```
 
-where `Γ` is the constant covariance matrix.
+# Arguments
+- `Γ`: Square, positive-semidefinite covariance matrix.
+- `t0`: Initial time.
+- `W0`: Initial process value and prototype; its length must match `Γ`.
+- `Z0`: Optional auxiliary process value.
+
+# Keywords
+- `rng`: Random number generator used for increments.
+
+# Returns
+A `NoiseProcess` with `isinplace(W) == false`.
 """
 function CorrelatedWienerProcess(
         Γ, t0, W0, Z0 = nothing;
@@ -53,16 +65,30 @@ function construct_correlated_noisefunc!(Γ)
     return dist, bridge
 end
 
-@doc doc"""
-One can define a `CorrelatedWienerProcess` which is a Wiener process with
-correlations between the Wiener processes. The constructor is:
+"""
+    CorrelatedWienerProcess!(Γ, t0, W0, Z0 = nothing; rng = Random.default_rng())
+
+Construct the in-place variant of [`CorrelatedWienerProcess`](@ref). It uses
+the same constant covariance model and writes increments into `W0`-shaped
+storage.
 
 ```julia
-CorrelatedWienerProcess(Γ,t0,W0,Z0=nothing;kwargs...)
-CorrelatedWienerProcess!(Γ,t0,W0,Z0=nothing;kwargs...)
+Γ = [1.0 0.2; 0.2 1.0]
+W = CorrelatedWienerProcess!(Γ, 0.0, zeros(2))
+calculate_step!(W, 0.01, nothing, nothing)
 ```
 
-where `Γ` is the constant covariance matrix.
+# Arguments
+- `Γ`: Square, positive-semidefinite covariance matrix.
+- `t0`: Initial time.
+- `W0`: Initial process value and storage prototype.
+- `Z0`: Optional auxiliary process value.
+
+# Keywords
+- `rng`: Random number generator used for increments.
+
+# Returns
+A `NoiseProcess` with `isinplace(W) == true`.
 """
 function CorrelatedWienerProcess!(
         Γ, t0, W0, Z0 = nothing;

--- a/src/geometric_bm.jl
+++ b/src/geometric_bm.jl
@@ -125,23 +125,38 @@ function gbm_bridge!(rand_vec, gbm, W, W0, Wh, q, h, u, p, t, rng)
     return @.. rand_vec = exp(rand_vec) - W0
 end
 
-@doc doc"""
+"""
+    GeometricBrownianMotionProcess(μ, σ, t0, W0, Z0 = nothing; kwargs...)
+
 A `GeometricBrownianMotion` process is a Wiener process with
 constant drift `μ` and constant diffusion `σ`. I.e. this is the solution of the
 stochastic differential equation
 
 ```math
-dX_t = \mu X_t dt + \sigma X_t dW_t
+dX_t = \\mu X_t dt + \\sigma X_t dW_t
 ```
 
-The `GeometricBrownianMotionProcess` is distribution exact (meaning, not a numerical
-solution of the stochastic differential equation, but instead follows the exact
-distribution properties). It can be back interpolated exactly as well. The constructor is:
+The process is distribution exact rather than a numerical approximation and can
+be back-interpolated exactly.
 
 ```julia
-GeometricBrownianMotionProcess(μ,σ,t0,W0,Z0=nothing;kwargs...)
-GeometricBrownianMotionProcess!(μ,σ,t0,W0,Z0=nothing;kwargs...)
+W = GeometricBrownianMotionProcess(0.05, 0.2, 0.0, 1.0)
+sol = solve(NoiseProblem(W, (0.0, 1.0)); dt = 0.01)
 ```
+
+# Arguments
+- `μ`: Constant drift coefficient.
+- `σ`: Constant diffusion coefficient.
+- `t0`: Initial time.
+- `W0`: Initial process value and prototype.
+- `Z0`: Optional auxiliary process value.
+
+# Keywords
+Additional keywords are forwarded to `NoiseProcess`, including `rswm`,
+`save_everystep`, `rng`, `reset`, `reseed`, and `continuous`.
+
+# Returns
+A `NoiseProcess` with `isinplace(W) == false`.
 """
 function GeometricBrownianMotionProcess(μ, σ, t0, W0, Z0 = nothing; kwargs...)
     gbm = GeometricBrownianMotion(μ, σ)
@@ -196,23 +211,38 @@ function (X::GeometricBrownianMotion!)(rand_vec, W, dt, u, p, t, rng) #dist!
     return @.. rand_vec = W.W[end] * expm1(X.μ - (1 / 2) * X.σ * dt + X.σ * sqrt(dt) * rand_vec)
 end
 
-@doc doc"""
+"""
+    GeometricBrownianMotionProcess!(μ, σ, t0, W0, Z0 = nothing; kwargs...)
+
 A `GeometricBrownianMotion` process is a Wiener process with
 constant drift `μ` and constant diffusion `σ`. I.e. this is the solution of the
 stochastic differential equation
 
 ```math
-dX_t = \mu X_t dt + \sigma X_t dW_t
+dX_t = \\mu X_t dt + \\sigma X_t dW_t
 ```
 
-The `GeometricBrownianMotionProcess` is distribution exact (meaning, not a numerical
-solution of the stochastic differential equation, but instead follows the exact
-distribution properties). It can be back interpolated exactly as well. The constructor is:
+The process is distribution exact rather than a numerical approximation and can
+be back-interpolated exactly. This variant writes increments into preallocated
+storage.
 
 ```julia
-GeometricBrownianMotionProcess(μ,σ,t0,W0,Z0=nothing;kwargs...)
-GeometricBrownianMotionProcess!(μ,σ,t0,W0,Z0=nothing;kwargs...)
+W = GeometricBrownianMotionProcess!(0.05, 0.2, 0.0, zeros(2))
+calculate_step!(W, 0.01, nothing, nothing)
 ```
+
+# Arguments
+- `μ`: Constant drift coefficient.
+- `σ`: Constant diffusion coefficient.
+- `t0`: Initial time.
+- `W0`: Initial process value and storage prototype.
+- `Z0`: Optional auxiliary process value.
+
+# Keywords
+Additional keywords are forwarded to `NoiseProcess`.
+
+# Returns
+A `NoiseProcess` with `isinplace(W) == true`.
 """
 function GeometricBrownianMotionProcess!(μ, σ, t0, W0, Z0 = nothing; kwargs...)
     gbm = GeometricBrownianMotion!(μ, σ)

--- a/src/noise_interfaces/noise_process_interface.jl
+++ b/src/noise_interfaces/noise_process_interface.jl
@@ -1,8 +1,18 @@
 """
-    save_noise!(W::NoiseProcess)
+    save_noise!(W::AbstractNoiseProcess)
 
-Save the current noise value and time to the process history if it hasn't been saved already.
-This function is called automatically by the stepping algorithms to maintain the noise trajectory.
+Save the current time and noise value to the process history when the concrete
+process stores a history. Solver integrations call this after an accepted step.
+
+# Interface rules
+- Implementations must be idempotent when the current time is already the last
+  saved time.
+- Primary and optional auxiliary values must remain aligned with the saved times.
+- Function- and transport-based processes may implement this as a no-op because
+  they evaluate values lazily.
+
+# Returns
+`nothing`.
 """
 @inline function save_noise!(W::NoiseProcess)
     if W.t != W.curt
@@ -16,17 +26,22 @@ This function is called automatically by the stepping algorithms to maintain the
 end
 
 """
-    accept_step!(W::NoiseProcess, dt, u, p, setup_next = true)
+    accept_step!(W::AbstractNoiseProcess, dt, u, p, setup_next = true)
 
-Accept a noise step, updating the current time and noise values.
-This function is called by the SDE solvers after a successful integration step.
+Commit the pending increment prepared by `calculate_step!` or
+`setup_next_step!`. A concrete implementation must advance the current time by
+the pending step, update primary and auxiliary values exactly once, and store
+the proposed next step `dt`.
 
-## Arguments
-- `W`: The noise process
-- `dt`: Time step size (may differ from W.dt due to adaptivity)
-- `u`: Current solution value (for state-dependent noise)
-- `p`: Parameters (for state-dependent noise)
-- `setup_next`: Whether to prepare for the next step
+# Arguments
+- `W`: Noise process being advanced.
+- `dt`: Proposed width of the next step; it may differ from the pending width.
+- `u`: Current differential-equation state, or `nothing` when unused.
+- `p`: Current parameters, or `nothing` when unused.
+- `setup_next`: If `true`, prepare the next pending increment before returning.
+
+# Returns
+`nothing`.
 """
 @inline function accept_step!(W::NoiseProcess, dt, u, p, setup_next = true)
     W.curt += W.dt
@@ -61,24 +76,24 @@ This function is called by the SDE solvers after a successful integration step.
 end
 
 """
-    setup_next_step!(W::NoiseProcess, u, p)
+    setup_next_step!(W::AbstractNoiseProcess, u, p)
 
-Prepare the noise process for the next integration step.
+Prepare the pending increment for the process's current `W.dt`.
 
-This function manages the Rejection Sampling with Memory (RSWM) algorithm,
-handling the stacks of pre-computed noise values for adaptive time stepping.
+# Interface rules
+The method is called before the first step and after an accepted step. It must
+leave a valid pending increment for `calculate_step!`/`accept_step!`, and it must
+preserve the distributional contract of the concrete process when adaptive
+steps are reused. `NoiseProcess` uses RSwM stacks; function, transport, grid,
+and VBT implementations may prepare a value directly.
 
 # Arguments
-- `W`: The noise process
-- `u`: Current solution value (for state-dependent noise)
-- `p`: Parameters (for state-dependent noise)
+- `W`: Noise process to prepare.
+- `u`: Current differential-equation state, or `nothing` when unused.
+- `p`: Current parameters, or `nothing` when unused.
 
-# Details
-The function implements different variants of the RSWM algorithm:
-- RSwM0: No memory - always recalculates (for state-dependent noise like compound Poisson)
-- RSwM1: Basic rejection sampling with single stack
-- RSwM2: Improved version with better memory management
-- RSwM3: Most advanced version with two-stack system (recommended for Brownian motion)
+# Returns
+`nothing`.
 """
 @inline function setup_next_step!(W::NoiseProcess, u, p)
     # RSwM0: No memory - always recalculate fresh noise
@@ -255,21 +270,25 @@ The function implements different variants of the RSWM algorithm:
 end
 
 """
-    calculate_step!(W::NoiseProcess, dt, u, p)
+    calculate_step!(W::AbstractNoiseProcess, dt, u, p)
 
-Calculate noise increments for the given time step.
+Calculate and store the pending noise increment for a proposed step.
 
-This function generates new random values for the noise process according
-to its distribution function.
+# Interface rules
+The pending increment must represent the process change over `dt` from the
+current state. Implementations must update pending-step state without committing
+the step; `accept_step!` performs the commit. In-place processes write into
+existing increment buffers, while out-of-place processes may allocate values.
 
 # Arguments
-- `W`: The noise process
-- `dt`: Time step size
-- `u`: Current solution value (for state-dependent noise)
-- `p`: Parameters (for state-dependent noise)
+- `W`: Noise process whose increment is prepared.
+- `dt`: Proposed step width.
+- `u`: Current differential-equation state, or `nothing` when unused.
+- `p`: Current parameters, or `nothing` when unused.
 
-# Effects
-Updates W.dW (and W.dZ if auxiliary process exists) with new noise increments
+# Returns
+The concrete process may return `nothing` or the selected step width. Callers
+should use the process state rather than depend on this return value.
 """
 @inline function calculate_step!(W::NoiseProcess, dt, u, p)
     if isinplace(W)
@@ -288,28 +307,25 @@ Updates W.dW (and W.dZ if auxiliary process exists) with new noise increments
 end
 
 """
-    reject_step!(W::NoiseProcess, dtnew, u, p)
+    reject_step!(W::AbstractNoiseProcess, dtnew, u, p)
 
-Handle rejection of a time step in adaptive algorithms.
+Replace the pending step after an adaptive solver rejects the current proposal.
 
-When an adaptive SDE solver rejects a step, this function uses bridge
-interpolation to generate appropriate noise values for the smaller time step,
-maintaining distributional correctness.
+# Interface rules
+The replacement increment must have the same conditional distribution as the
+original process over `dtnew`; implementations with rejection memory may retain
+the unused portion for later steps. `dtnew` has the sign of the current step and
+is normally smaller in magnitude. A process that cannot preserve this contract
+must throw an informative error instead of silently reusing an invalid increment.
 
 # Arguments
-- `W`: The noise process
-- `dtnew`: New (smaller) time step after rejection
-- `u`: Current solution value (for state-dependent noise)
-- `p`: Parameters (for state-dependent noise)
+- `W`: Noise process with a pending step.
+- `dtnew`: Replacement step width.
+- `u`: Current differential-equation state, or `nothing` when unused.
+- `p`: Current parameters, or `nothing` when unused.
 
-# Details
-The function implements different behaviors based on the RSWM algorithm:
-- RSwM0: Uses bridging but discards future values (appropriate for tau-leaping)
-- RSwM1/2/3: Stores unused portions of noise in stacks for later use
-
-For tau-leaping with state-dependent rates, the rate λ is approximated as constant, so
-storing future values generated with the wrong rate doesn't make sense. RSwM0 discards
-the unused portion after bridging and recalculates fresh noise for subsequent steps.
+# Returns
+`nothing`.
 """
 @inline function reject_step!(W::NoiseProcess, dtnew, u, p)
     q = dtnew / W.dt

--- a/src/ornstein_uhlenbeck.jl
+++ b/src/ornstein_uhlenbeck.jl
@@ -134,22 +134,36 @@ function ou_bridge!(rand_vec, ou, W, W0, Wh, q, h, u, p, t, rng)
     ) * rand_vec
 end
 
-@doc doc"""
-a `Ornstein-Uhlenbeck` process, which is a Wiener process defined
+"""
+    OrnsteinUhlenbeckProcess(Θ, μ, σ, t0, W0, Z0 = nothing; kwargs...)
+
+An `Ornstein-Uhlenbeck` process is a Wiener process defined
 by the stochastic differential equation
 
 ```math
-dX_t = \theta (\mu - X_t) dt + \sigma dW_t
+dX_t = \\theta (\\mu - X_t) dt + \\sigma dW_t
 ```
 
-The `OrnsteinUhlenbeckProcess` is distribution exact (meaning, not a numerical
-solution of the stochastic differential equation, but instead follows the exact
-distribution properties). The constructor is:
+The process is distribution exact rather than a numerical approximation.
 
 ```julia
-OrnsteinUhlenbeckProcess(Θ,μ,σ,t0,W0,Z0=nothing;kwargs...)
-OrnsteinUhlenbeckProcess!(Θ,μ,σ,t0,W0,Z0=nothing;kwargs...)
+W = OrnsteinUhlenbeckProcess(2.0, 0.0, 0.3, 0.0, 1.0)
+sol = solve(NoiseProblem(W, (0.0, 1.0)); dt = 0.01)
 ```
+
+# Arguments
+- `Θ`: Mean-reversion rate.
+- `μ`: Long-term mean.
+- `σ`: Diffusion coefficient.
+- `t0`: Initial time.
+- `W0`: Initial process value and prototype.
+- `Z0`: Optional auxiliary process value.
+
+# Keywords
+Additional keywords are forwarded to `NoiseProcess`.
+
+# Returns
+A `NoiseProcess` with `isinplace(W) == false`.
 """
 function OrnsteinUhlenbeckProcess(Θ, μ, σ, t0, W0, Z0 = nothing; kwargs...)
     ou = OrnsteinUhlenbeck(Θ, μ, σ)
@@ -216,22 +230,37 @@ function (X::OrnsteinUhlenbeck!)(rand_vec, W, dt, u, p, t, rng) #dist!
         rand_vec * X.σ * sqrt((-expm1.(-2 * X.Θ .* dt)) / (2 * X.Θ)) - W.curW
 end
 
-@doc doc"""
-A `Ornstein-Uhlenbeck` process, which is a Wiener process defined
+"""
+    OrnsteinUhlenbeckProcess!(Θ, μ, σ, t0, W0, Z0 = nothing; kwargs...)
+
+An `Ornstein-Uhlenbeck` process is a Wiener process defined
 by the stochastic differential equation
 
 ```math
-dX_t = \theta (\mu - X_t) dt + \sigma dW_t
+dX_t = \\theta (\\mu - X_t) dt + \\sigma dW_t
 ```
 
-The `OrnsteinUhlenbeckProcess` is distribution exact (meaning, not a numerical
-solution of the stochastic differential equation, but instead follows the exact
-distribution properties). The constructor is:
+The process is distribution exact rather than a numerical approximation. This
+variant writes increments into preallocated storage.
 
 ```julia
-OrnsteinUhlenbeckProcess(Θ,μ,σ,t0,W0,Z0=nothing;kwargs...)
-OrnsteinUhlenbeckProcess!(Θ,μ,σ,t0,W0,Z0=nothing;kwargs...)
+W = OrnsteinUhlenbeckProcess!(2.0, 0.0, 0.3, 0.0, zeros(2))
+calculate_step!(W, 0.01, nothing, nothing)
 ```
+
+# Arguments
+- `Θ`: Mean-reversion rate.
+- `μ`: Long-term mean.
+- `σ`: Diffusion coefficient.
+- `t0`: Initial time.
+- `W0`: Initial process value and storage prototype.
+- `Z0`: Optional auxiliary process value.
+
+# Keywords
+Additional keywords are forwarded to `NoiseProcess`.
+
+# Returns
+A `NoiseProcess` with `isinplace(W) == true`.
 """
 function OrnsteinUhlenbeckProcess!(Θ, μ, σ, t0, W0, Z0 = nothing; kwargs...)
     ou = OrnsteinUhlenbeck!(Θ, μ, σ)

--- a/src/pCN.jl
+++ b/src/pCN.jl
@@ -26,11 +26,31 @@ function generate_innovation(W0, t, rng)
     )
 end
 
-@doc doc"""
+"""
     pCN!(noise::AbstractNoiseProcess, ρ; reset=true,reverse=false,indx=nothing)
 
-Create a new, but correlated noise process from `noise` and additional entropy with correlation ρ.
-This update defines an autoregressive process in the space of Wiener (or noise process) trajectories, which can be used as proposal distribution in Metropolis-Hastings algorithms (often called the "preconditioned Crank–Nicolson scheme".)
+Create a correlated noise proposal in-place using the preconditioned
+Crank–Nicolson update. The source path is replaced by
+`ρ * source + sqrt(1 - ρ^2) * innovation`.
+
+# Arguments
+- `noise`: Source `AbstractNoiseProcess` whose saved path is updated.
+- `ρ`: Correlation parameter, normally in `[-1, 1]`.
+
+# Keywords
+- `reset`: Whether the returned wrapper resets before solving.
+- `reverse`: Whether the returned wrapper traverses the source backwards.
+- `indx`: Initial source index for the wrapper; defaults to the start (or end
+  when `reverse = true`).
+
+# Returns
+A `NoiseWrapper` around the updated source. The source itself is mutated.
+
+# Example
+```julia
+W = WienerProcess(0.0, 0.0)
+proposal = pCN!(W, 0.9)
+```
 
 External links
  * [Preconditioned Crank–Nicolson algorithm on Wikipedia](https://en.wikipedia.org/wiki/Preconditioned_Crank–Nicolson_algorithm)
@@ -51,7 +71,26 @@ end
 """
     pCN(noise::AbstractNoiseProcess, ρ; reset=true,reverse=false,indx=nothing)
 
-Create a new, but correlated noise process from `noise` and additional entropy with correlation ρ.
+Create a correlated noise proposal from a copy of `noise` using the
+preconditioned Crank–Nicolson update. The input process is not mutated.
+
+# Arguments
+- `noise`: Source `AbstractNoiseProcess` with a saved path.
+- `ρ`: Correlation parameter, normally in `[-1, 1]`.
+
+# Keywords
+- `reset`: Whether the returned wrapper resets before solving.
+- `reverse`: Whether the returned wrapper traverses the source backwards.
+- `indx`: Initial source index for the wrapper.
+
+# Returns
+A `NoiseWrapper` containing the correlated proposal.
+
+# Example
+```julia
+W = WienerProcess(0.0, 0.0)
+proposal = pCN(W, 0.9)
+```
 """
 function pCN(
         source::AbstractNoiseProcess{T, N, Vector{T2}, inplace}, ρ;
@@ -70,8 +109,25 @@ end
 """
     pCN(noise::NoiseGrid, ρ; reset=true, rng = Random.default_rng())
 
-Create a new, but correlated noise process from `noise` and additional entropy with correlation ρ.
-This update defines an autoregressive process in the space of Wiener (or noise process) trajectories, which can be used as proposal distribution in Metropolis-Hastings algorithms (often called the "preconditioned Crank–Nicolson scheme".)
+Create a correlated proposal from a `NoiseGrid`. The source grid is not
+mutated; the returned grid has the same time points and auxiliary process.
+
+# Arguments
+- `noise`: Source `NoiseGrid`.
+- `ρ`: Correlation parameter, normally in `[-1, 1]`.
+
+# Keywords
+- `reset`: Reset flag stored on the returned grid.
+- `rng`: Random number generator used for the innovation.
+
+# Returns
+A new `NoiseGrid` containing the correlated proposal.
+
+# Example
+```julia
+grid = NoiseGrid(0.0:0.1:1.0, zeros(11))
+proposal = pCN(grid, 0.9)
+```
 
 External links
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -30,6 +30,19 @@ NoiseProcess(t0, W0, Z0, dist, bridge;
   - `reset` whether to reset the process with each solve.
   - `reseed` whether to reseed the process with each solve.
 
+# Fields
+- `t`: Saved time points, in traversal order.
+- `W`: Saved primary process values corresponding to `t`.
+- `Z`: Saved auxiliary process values, or `nothing` when unused.
+- `curt`, `curW`, `curZ`: Current time and current primary/auxiliary values.
+- `dt`, `dW`, `dZ`: Proposed step width and pending increments.
+- `dist`, `bridge`: Step and bridge callbacks.
+- `covariance`, `rswm`, `save_everystep`, `rng`, `reset`, `reseed`, `continuous`:
+  Process configuration.
+
+The stack and scratch-buffer fields are implementation details. Solvers should
+use the exported step functions instead of reading or mutating those fields.
+
 The signature for the `dist` is:
 
 ```julia
@@ -362,6 +375,16 @@ SimpleNoiseProcess{iip}(t0, W0, Z0, dist, bridge;
   - `rng` the local RNG used for generating the random numbers.
   - `reset` whether to reset the process with each solve.
   - `reseed` whether to reseed the process with each solve.
+
+# Fields
+- `t`, `W`, `Z`: Saved times and primary/auxiliary values.
+- `curt`, `curW`, `curZ`: Current time and current values.
+- `dt`, `dW`, `dZ`: Proposed step and pending increments.
+- `dist`, `bridge`: Distribution and bridge callbacks.
+- `covariance`, `save_everystep`, `rng`, `reset`, `reseed`: Stored options.
+
+The process does not retain rejection-memory stacks. Adaptive solvers must not
+call `reject_step!` on it.
 """
 mutable struct SimpleNoiseProcess{
         T, N, Tt, T2, T3, ZType, F, F2, CovType, inplace, RNGType,
@@ -452,6 +475,24 @@ convergence testing.
 NoiseWrapper(source::AbstractNoiseProcess{T, N, Vector{T2}, inplace};
     reset = true, reverse = false, indx = nothing) where {T, N, T2, inplace}
 ```
+
+# Arguments
+- `source`: Existing noise process whose saved path will be replayed.
+
+# Keywords
+- `reset`: Whether solving a problem reinitializes the wrapper.
+- `reverse`: Whether interpolation follows the source path backwards.
+- `indx`: Initial source index. It defaults to the first index, or the last
+  index when `reverse = true`.
+
+# Fields
+- `t`, `W`, `Z`: The wrapper's saved replay path.
+- `curt`, `curW`, `curZ`: Current replay position and values.
+- `source`: Underlying process providing interpolation.
+- `reset`, `reverse`: Replay options.
+
+The saved path and current values are owned by the wrapper; the source is not
+mutated by interpolation.
 
 ## NoiseWrapper Example
 
@@ -624,8 +665,27 @@ NoiseFunction{iip}(t0, W, Z = nothing;
     reset = true) where {iip}
 ```
 
+# Arguments
+- `t0`: Initial time.
+- `W`: Primary function, called as `W(u, p, t)` or `W(out, u, p, t)`.
+- `Z`: Optional auxiliary function with the same calling convention.
+
+# Keywords
+- `noise_prototype`: Initial value and storage prototype for in-place functions.
+- `reset`: Whether solving a problem resets the current time and values.
+
+# Fields
+- `W`, `Z`: Primary and optional auxiliary functions.
+- `t0`, `curt`: Initial and current times.
+- `curW`, `curZ`: Current function values.
+- `dt`, `dW`, `dZ`: Proposed step and pending increments.
+- `reset`: Reset behavior.
+
+`NoiseFunction` evaluates a deterministic function lazily; it does not retain
+a complete saved path.
+
 Additionally, one can use an in-place function `W(out1,out2,t)` for more efficient
-generation of the arrays for mulitidimensional processes. When the in-place version
+generation of the arrays for multidimensional processes. When the in-place version
 is used without a dispatch for the out-of-place version, the `noise_prototype`
 needs to be set.
 
@@ -639,7 +699,7 @@ f(u, p, t) = exp(t)
 W = NoiseFunction(0.0, f)
 ```
 
-If it's mulitidimensional and an in-place function is used, the `noise_prototype`
+If it's multidimensional and an in-place function is used, the `noise_prototype`
 must be given. For example:
 
 ```julia
@@ -753,8 +813,28 @@ NoiseTransport(t0,
     kwargs...)
 ```
 
+# Arguments
+- `t0`: Initial time.
+- `W`: Primary transport function, called as `W(u, p, t, rv)` or
+  `W(out, u, p, t, rv)`.
+- `RV`: Random-variable generator, called as `RV(rng)` or `RV(rng, rv)`.
+- `rv`: Optional realization or mutable realization prototype.
+- `Z`: Optional auxiliary transport function.
+
+# Keywords
+- `rng`: Random number generator used to draw realizations.
+- `reset`: Whether solving a problem resets the process.
+- `reseed`: Whether a new realization is drawn when the process is reseeded.
+- `noise_prototype`: Initial output shape for in-place transport functions.
+
+# Fields
+- `W`, `Z`: Primary and optional auxiliary transport functions.
+- `RV`, `rv`: Random-variable generator and current realization.
+- `curt`, `curW`, `curZ`: Current time and transported values.
+- `rng`, `reset`, `reseed`: Randomness and reset controls.
+
 Additionally, one can use an in-place function `W(out, u, p, t, rv)` for more efficient
-generation of the arrays for mulitidimensional processes. When the in-place version
+generation of the arrays for multidimensional processes. When the in-place version
 is used without a dispatch for the out-of-place version, the `noise_prototype`
 needs to be set.
 
@@ -783,7 +863,7 @@ p = (π, 2π)
 W = NoiseTransport(t0, f, randn!, rv, noise_prototype = f(nothing, p, t0, rv))
 ```
 
-If the random process is expected to be mulitidimensional, it is preferable to use an in-place transport function, and, in this case, the `noise_prototype` must be given. Here is an example with a scalar random vector with a beta distribution, from `Distributions.jl`.
+If the random process is expected to be multidimensional, it is preferable to use an in-place transport function, and, in this case, the `noise_prototype` must be given. Here is an example with a scalar random vector with a beta distribution, from `Distributions.jl`.
 
 ```julia
 f!(out, u, p, t, rv) = (out .= sin.(rv * t))
@@ -793,7 +873,7 @@ rv = 0.0
 W = NoiseTransport(t0, f!, RV, rv, noise_prototype = zeros(4))
 ```
 
-We can also have a random vector with a mulitidimensional process, in which case an in-place version of `RV` is required. For example.
+We can also have a random vector with a multidimensional process, in which case an in-place version of `RV` is required. For example.
 
 ```julia
 using Random: randn!
@@ -926,8 +1006,25 @@ suggested that the grid size at least approximates the number of
 time steps in the integration to ensure accuracy.
 
 For a one-dimensional process, `W` should be an `AbstractVector` of `Number`s.
-For mulitidimensional processes, `W` should be an `AbstractVector` of the
+For multidimensional processes, `W` should be an `AbstractVector` of the
 `noise_prototype`.
+
+# Arguments
+- `t`: Strictly monotone time points.
+- `W`: Values at the time points, with `length(W) == length(t)`.
+- `Z`: Optional auxiliary values with the same time grid.
+
+# Keywords
+- `reset`: Whether solving a problem resets the current grid position.
+
+# Fields
+- `t`, `W`, `Z`: Input grid and primary/auxiliary values.
+- `curt`, `curW`, `curZ`: Current interpolated position and values.
+- `dt`, `dW`, `dZ`: Proposed step and pending increments.
+- `reset`: Reset behavior.
+
+Interpolation is linear. A grid is convenient for replaying sampled data, but
+it is not distributionally exact between sparse points.
 
 ## NoiseGrid
 
@@ -1041,6 +1138,19 @@ final time point as `Inf`. Note that the time points do not have to match the
 time points of the future integration, since the interpolant of the SDE solution
 will be used. Thus, the limiting factor is error tolerance, and not hitting specific
 points.
+
+# Arguments
+- `source1`: Initialized `DEIntegrator` providing the primary noise path.
+- `source2`: Optional second integrator providing the auxiliary path.
+
+# Keywords
+- `reset`: Whether solving a problem reinitializes both copied integrators.
+
+# Fields
+- `source1`, `source2`: Deep-copied integrators used for interpolation.
+- `t`, `W`, `Z`: Saved source time points and values.
+- `curt`, `curW`, `curZ`: Current time and values.
+- `reset`: Reset behavior.
 
 ## NoiseApproximation Example
 
@@ -1165,9 +1275,21 @@ as a keyword argument. The following keyword arguments are available:
   - `rng` the splittable PRNG used for generating the random numbers.
     Default: `Xoshiro()` from the Random package.
 
+# Fields
+- `dist`, `bridge`: Endpoint distribution and bridge callbacks.
+- `t`, `W`, `Z`: Cached endpoints and auxiliary values.
+- `curt`, `curW`, `curZ`: Current time and values.
+- `dt`, `dW`, `dZ`: Proposed step and pending increments.
+- `seeds`: Integer seeds used to make recursive bridge queries reproducible.
+- `atol`, `tree_depth`, `search_depth`, `rng`: Accuracy, cache, search, and
+  random-generation controls.
+
+The recursive cache and scratch buffers are implementation details; use the
+callable and step interfaces rather than mutating them directly.
+
 ## VirtualBrownianTree Example
 
-In this example, we define a mulitidimensional Brownian process based on a
+In this example, we define a multidimensional Brownian process based on a
 `VirtualBrownianTree` with a minimal `tree_depth=0` such that memory consumption
 is minimized.
 
@@ -1347,6 +1469,29 @@ BoxWedgeTail{iip}(t0, W0, Z0, dist, bridge;
     rng = Random.default_rng(),
     reset = true, reseed = true) where {iip}
 ```
+
+# Arguments
+- `t0`: Initial time.
+- `W0`: Two-dimensional Brownian initial value.
+- `Z0`: Optional auxiliary process value.
+- `dist`, `bridge`: In-place or out-of-place increment callbacks.
+
+# Keywords
+- `rtol`: Relative tolerance used to build the stochastic-area density.
+- `nr`, `na`, `nz`: Discretization levels for radius, angle, and tail grids.
+- `box_grouping`: `:MinEntropy`, `:Columns`, or `:none`.
+- `sqeezing`: Whether the wedge sampler uses squeezing bounds.
+- `save_everystep`, `rng`, `reset`, `reseed`: Standard process controls.
+
+# Fields
+- `t`, `W`, `Z`: Saved times and primary/auxiliary values.
+- `A`: Saved stochastic-area values.
+- `curt`, `curW`, `curZ`, `curA`: Current state.
+- `rtol`, `Δr`, `Δa`, `Δz`: Stochastic-area discretization controls.
+- `boxes`, `wedges`, `tails`: Sampling tables used by the implementation.
+
+The sampling tables are generated data, not extension points. Use the process
+and step interfaces rather than mutating them directly.
 """
 mutable struct BoxWedgeTail{
         T, N, Tt, TA, T2, T3, ZType, F, F2, inplace, RNGType, tolType,

--- a/src/wiener.jl
+++ b/src/wiener.jl
@@ -214,32 +214,75 @@ function VBT_BRIDGE(dW, W, W0, Wh, q, h, u, p, t, rng)
     end
 end
 
-@doc doc"""
-The `WienerProcess`, also known as Brownian motion, or
-the noise in the Langevin equation, is the stationary process with
-white noise increments and a distribution `N(0,dt)`. The constructor is:
+"""
+    WienerProcess(t0, W0, Z0 = nothing; kwargs...)
+
+Construct an out-of-place Wiener process (Brownian motion). Its increments
+have distribution `N(0, abs(dt))`, and values between generated points are
+sampled with a Brownian bridge.
 
 ```julia
-WienerProcess(t0,W0,Z0=nothing;kwargs...)
-WienerProcess!(t0,W0,Z0=nothing;kwargs...)
+W = WienerProcess(0.0, 0.0)
+sol = solve(NoiseProblem(W, (0.0, 1.0)); dt = 0.01)
+sol(0.5)
 ```
+
+# Arguments
+- `t0`: Initial time.
+- `W0`: Initial noise value and prototype for the process shape and element type.
+- `Z0`: Optional auxiliary process value for higher-order methods.
+
+# Keywords
+- `rswm`: Rejection Sampling with Memory configuration.
+- `save_everystep`: Whether to retain every generated time and value.
+- `covariance`: Optional covariance metadata.
+- `rng`: Random number generator used for increments.
+- `reset`: Whether solving a problem reinitializes the process.
+- `reseed`: Whether solving without an explicit seed reseeds `rng`.
+- `continuous`: Whether interpolation includes the left endpoint in its mean.
+
+Additional keywords are forwarded to `NoiseProcess`.
+
+# Returns
+A `NoiseProcess` with `isinplace(W) == false`.
 """
 function WienerProcess(t0, W0, Z0 = nothing; kwargs...)
     return NoiseProcess{false}(t0, W0, Z0, WHITE_NOISE_DIST, WHITE_NOISE_BRIDGE; kwargs...)
 end
 
-@doc doc"""
-The `SimpleWienerProcess`, also known as Brownian motion, or
-the noise in the Langevin equation, is the stationary process with
-white noise increments and a distribution `N(0,dt)`. The constructor is:
+"""
+    SimpleWienerProcess(t0, W0, Z0 = nothing; kwargs...)
+
+Construct a lightweight out-of-place Wiener process. Unlike
+[`WienerProcess`](@ref), this process cannot recover a rejected adaptive step
+and must be used with a fixed-step solver.
 
 ```julia
-SimpleWienerProcess(t0,W0,Z0=nothing;kwargs...)
-SimpleWienerProcess(t0,W0,Z0=nothing;kwargs...)
+W = SimpleWienerProcess(0.0, 0.0)
+sol = solve(NoiseProblem(W, (0.0, 1.0)); dt = 0.01)
 ```
 
-Unlike WienerProcess, this uses the SimpleNoiseProcess and thus does not
-support adaptivity, but is slightly more lightweight.
+# Arguments
+- `t0`: Initial time.
+- `W0`: Initial noise value and prototype for the process shape and element type.
+- `Z0`: Optional auxiliary process value.
+
+# Keywords
+- `save_everystep`: Whether to retain every generated time and value.
+- `covariance`: Optional covariance metadata.
+- `rng`: Random number generator used for increments.
+- `reset`: Whether solving a problem reinitializes the process.
+- `reseed`: Whether solving without an explicit seed reseeds `rng`.
+
+Additional keywords are forwarded to `SimpleNoiseProcess`.
+
+# Returns
+A `SimpleNoiseProcess` with `isinplace(W) == false`.
+
+!!! warning
+
+    `SimpleWienerProcess` does not support adaptive step rejection. Use
+    `WienerProcess` when the solver may reject a step.
 """
 function SimpleWienerProcess(t0, W0, Z0 = nothing; kwargs...)
     return SimpleNoiseProcess{false}(t0, W0, Z0, WHITE_NOISE_DIST, WHITE_NOISE_BRIDGE; kwargs...)
@@ -326,15 +369,29 @@ function INPLACE_VBT_BRIDGE(rand_vec, W, W0, Wh, q, h, u, p, t, rng)
     return @.. rand_vec = sqrtcoeff * rand_vec + q * (W0 + Wh)
 end
 
-@doc doc"""
-The `WienerProcess`, also known as Brownian motion, or
-the noise in the Langevin equation, is the stationary process with
-white noise increments and a distribution `N(0,dt)`. The constructor is:
+"""
+    WienerProcess!(t0, W0, Z0 = nothing; kwargs...)
+
+Construct an in-place Wiener process. It has the same distribution and solver
+contract as [`WienerProcess`](@ref), but its distribution and bridge functions
+write into preallocated storage.
 
 ```julia
-WienerProcess(t0,W0,Z0=nothing;kwargs...)
-WienerProcess!(t0,W0,Z0=nothing;kwargs...)
+W = WienerProcess!(0.0, zeros(2))
+calculate_step!(W, 0.01, nothing, nothing)
 ```
+
+# Arguments
+- `t0`: Initial time.
+- `W0`: Initial array-valued noise and storage prototype.
+- `Z0`: Optional auxiliary process value.
+
+# Keywords
+The same process-control keywords as [`WienerProcess`](@ref) are accepted and
+forwarded to `NoiseProcess`.
+
+# Returns
+A `NoiseProcess` with `isinplace(W) == true`.
 """
 function WienerProcess!(t0, W0, Z0 = nothing; kwargs...)
     return NoiseProcess{true}(
@@ -343,18 +400,32 @@ function WienerProcess!(t0, W0, Z0 = nothing; kwargs...)
     )
 end
 
-@doc doc"""
-The `SimpleWienerProcess`, also known as Brownian motion, or
-the noise in the Langevin equation, is the stationary process with
-white noise increments and a distribution `N(0,dt)`. The constructor is:
+"""
+    SimpleWienerProcess!(t0, W0, Z0 = nothing; kwargs...)
+
+Construct an in-place lightweight Wiener process. It has the same
+non-adaptive restriction as [`SimpleWienerProcess`](@ref).
 
 ```julia
-SimpleWienerProcess(t0,W0,Z0=nothing;kwargs...)
-SimpleWienerProcess(t0,W0,Z0=nothing;kwargs...)
+W = SimpleWienerProcess!(0.0, zeros(2))
+calculate_step!(W, 0.01, nothing, nothing)
 ```
 
-Unlike WienerProcess, this uses the SimpleNoiseProcess and thus does not
-support adaptivity, but is slightly more lightweight.
+# Arguments
+- `t0`: Initial time.
+- `W0`: Initial array-valued noise and storage prototype.
+- `Z0`: Optional auxiliary process value.
+
+# Keywords
+The same process-control keywords as [`SimpleWienerProcess`](@ref) are
+accepted and forwarded to `SimpleNoiseProcess`.
+
+# Returns
+A `SimpleNoiseProcess` with `isinplace(W) == true`.
+
+!!! warning
+
+    Do not pass this process to an adaptive solver.
 """
 function SimpleWienerProcess!(t0, W0, Z0 = nothing; kwargs...)
     return SimpleNoiseProcess{true}(
@@ -420,17 +491,27 @@ function REAL_WHITE_NOISE_BRIDGE(dW, W, W0, Wh, q, h, u, p, t, rng)
     end
 end
 
-@doc doc"""
-The `RealWienerProcess` is a Brownian motion that is forced to be
-real-valued. While the normal `WienerProcess` becomes complex valued
-if `W0` is complex, this version is real valued for when you want to,
-for example, solve an SDE defined by complex numbers where the noise
-is in the reals.
+"""
+    RealWienerProcess(t0, W0, Z0 = nothing; kwargs...)
+
+Construct an out-of-place Brownian process whose increments are real-valued,
+even when `W0` is complex. This is useful for complex SDE states driven by real
+noise.
 
 ```julia
-RealWienerProcess(t0,W0,Z0=nothing;kwargs...)
-RealWienerProcess!(t0,W0,Z0=nothing;kwargs...)
+W = RealWienerProcess(0.0, 0.0 + 0im)
 ```
+
+# Arguments
+- `t0`: Initial time.
+- `W0`: Initial value and prototype for the process shape.
+- `Z0`: Optional auxiliary process value.
+
+# Keywords
+The same process-control keywords as [`WienerProcess`](@ref) are accepted.
+
+# Returns
+A `NoiseProcess` with `isinplace(W) == false`.
 """
 function RealWienerProcess(t0, W0, Z0 = nothing; kwargs...)
     return NoiseProcess{false}(
@@ -488,17 +569,27 @@ function REAL_INPLACE_WHITE_NOISE_BRIDGE(rand_vec, W, W0, Wh, q, h, u, p, t, rng
     return @.. rand_vec = @fastmath sqrt((1 - q) * q * abs(h)) * rand_vec + q * Wh
 end
 
-@doc doc"""
-The `RealWienerProcess` is a Brownian motion that is forced to be
-real-valued. While the normal `WienerProcess` becomes complex valued
-if `W0` is complex, this version is real valued for when you want to,
-for example, solve an SDE defined by complex numbers where the noise
-is in the reals.
+"""
+    RealWienerProcess!(t0, W0, Z0 = nothing; kwargs...)
+
+Construct the in-place variant of [`RealWienerProcess`](@ref). It stores and
+updates its increment buffers rather than allocating new arrays.
 
 ```julia
-RealWienerProcess(t0,W0,Z0=nothing;kwargs...)
-RealWienerProcess!(t0,W0,Z0=nothing;kwargs...)
+W = RealWienerProcess!(0.0, zeros(2))
+calculate_step!(W, 0.01, nothing, nothing)
 ```
+
+# Arguments
+- `t0`: Initial time.
+- `W0`: Initial value and storage prototype.
+- `Z0`: Optional auxiliary process value.
+
+# Keywords
+The same process-control keywords as [`WienerProcess`](@ref) are accepted.
+
+# Returns
+A `NoiseProcess` with `isinplace(W) == true`.
 """
 function RealWienerProcess!(t0, W0, Z0 = nothing; kwargs...)
     return NoiseProcess{true}(

--- a/test/noise_process_interface.jl
+++ b/test/noise_process_interface.jl
@@ -1,0 +1,53 @@
+@testset "AbstractNoiseProcess lifecycle interface" begin
+    using DiffEqNoiseProcess
+    using SciMLBase: AbstractNoiseProcess
+
+    source = WienerProcess(0.0, 0.0; save_everystep = true)
+    calculate_step!(source, 0.1, nothing, nothing)
+    accept_step!(source, 0.1, nothing, nothing, false)
+
+    rejectable = AbstractNoiseProcess[
+        WienerProcess(0.0, 0.0),
+        NoiseFunction(0.0, (u, p, t) -> t),
+        NoiseTransport(0.0, (u, p, t, rv) -> rv * t, _ -> 1.0),
+        NoiseGrid(collect(0.0:0.1:1.0), collect(0.0:0.1:1.0)),
+        NoiseWrapper(source),
+    ]
+
+    for W in rejectable
+        @testset "$(nameof(typeof(W)))" begin
+            @test W(0.0) isa Tuple
+            @test setup_next_step!(W, nothing, nothing) === nothing
+            calculate_step!(W, 0.1, nothing, nothing)
+            @test reject_step!(W, 0.05, nothing, nothing) === nothing
+            @test accept_step!(W, 0.05, nothing, nothing, false) === nothing
+            @test save_noise!(W) === nothing
+        end
+    end
+
+    @testset "SimpleNoiseProcess rejects adaptive stepping" begin
+        W = SimpleWienerProcess(0.0, 0.0)
+        @test W isa AbstractNoiseProcess
+        @test setup_next_step!(W, nothing, nothing) === nothing
+        calculate_step!(W, 0.1, nothing, nothing)
+        @test_throws ErrorException reject_step!(W, 0.05, nothing, nothing)
+        @test accept_step!(W, 0.1, nothing, nothing, false) === nothing
+        @test save_noise!(W) === nothing
+    end
+
+    @testset "In-place callable contract" begin
+        processes = AbstractNoiseProcess[
+            WienerProcess!(0.0, zeros(2)),
+            NoiseFunction(
+                0.0,
+                (out, u, p, t) -> fill!(out, t),
+                noise_prototype = zeros(2),
+            ),
+        ]
+        for W in processes
+            out = zeros(2)
+            W(out, nothing, nothing, nothing, 0.0)
+            @test out == zeros(2)
+        end
+    end
+end


### PR DESCRIPTION
## Summary

- Move the public constructor and process-type documentation onto the original definitions and expand it with arguments, keywords, fields, return behavior, and executable examples.
- Document the exported lifecycle methods as developer-facing contracts and clarify that stack, cache, and scratch fields are not public extension points.
- Add generic lifecycle tests covering out-of-place, in-place, grid, wrapper, transport, function, and simple noise processes.
- Remove the legacy `@doc` attachment machinery. The package already has SciMLTesting `2.4` compatibility and uses the standard QA configuration without public-doc or reexport overrides.

There are no intended behavior changes.

## Verification

- `git diff --check`: passed
- `typos $(git diff --name-only --diff-filter=ACMRTUXB)`: passed
- Julia Runic check: passed
- `julia --startup-file=no --project -e 'using Test, DiffEqNoiseProcess; include("test/noise_process_interface.jl")'`: 32/32 passed
- `GROUP=Core julia --startup-file=no --project -e 'using Pkg; Pkg.test()'`: passed; all Core groups passed
- `GROUP=QA julia --startup-file=no --project -e 'using Pkg; Pkg.test()'`: 14 passed, 4 expected broken, 0 failed
- `run_api_docs(DiffEqNoiseProcess; rendered=true)`: 2/2 passed
- `timeout 3600 julia --startup-file=no --project=docs docs/make.jl`: rendered successfully; deployment was skipped because this was a local build

Please ignore this draft until reviewed by @ChrisRackauckas.
