### PR TITLE
qa: fix strict source findings

### DIFF
--- a/src/copy_noise_types.jl
+++ b/src/copy_noise_types.jl
@@ -1,4 +1,4 @@
-function Base.copy!(Wnew::T, W::T) where {T <: AbstractNoiseProcess}
+function Base.copy!(Wnew::T, W::T) where {T <: NoiseProcessType}
     for x in filter(!=(:u), fieldnames(typeof(W)))
         if getfield(W, x) isa Random.AbstractRNG
             setfield!(Wnew, x, copy(getfield(W, x)))

--- a/src/noise_interfaces/box_wedge_tail_interface.jl
+++ b/src/noise_interfaces/box_wedge_tail_interface.jl
@@ -120,6 +120,7 @@ end
             end
         else
             W0, Wh = W.W[i - 1], W.W[i]
+            Z0 = Zh = nothing
             if W.Z !== nothing
                 Z0, Zh = W.Z[i - 1], W.Z[i]
             end
@@ -206,6 +207,7 @@ end
             end
         else
             W0, Wh = W.W[i - 1], W.W[i]
+            Z0 = Zh = nothing
             if W.Z !== nothing
                 Z0, Zh = W.Z[i - 1], W.Z[i]
             end
@@ -305,6 +307,8 @@ function generate_boxes1(densf, Δr, Δa, Δz, rM, aM, offset = nothing, scale =
             end
 
             if offset !== nothing
+                indx1 = (i - 1) * scale + one(scale)
+                indx2 = (j - 1) * scale + one(scale)
                 offset[indx1:(indx1 + (scale - one(scale))), indx2:(indx2 + (scale - one(scale)))] .= z
             end
         end
@@ -373,6 +377,8 @@ function generate_boxes3(densf, Δr, Δa, Δz, rM, aM, offset = nothing, scale =
             end
             z -= Δz
             if offset !== nothing
+                indx1 = (i - 1) * scale + one(scale)
+                indx2 = (j - 1) * scale + one(scale)
                 offset[indx1:(indx1 + (scale - one(scale))), indx2:(indx2 + (scale - one(scale)))] .= z
             end
         end

--- a/src/noise_interfaces/common.jl
+++ b/src/noise_interfaces/common.jl
@@ -1,4 +1,4 @@
-DiffEqBase.has_reinit(i::AbstractNoiseProcess) = true
+DiffEqBase.has_reinit(i::NoiseProcessType) = true
 function DiffEqBase.reinit!(
         W::Union{NoiseProcess, NoiseApproximation}, dt;
         t0 = W.t[1],
@@ -127,7 +127,7 @@ function DiffEqBase.reinit!(
 end
 
 function DiffEqBase.reinit!(
-        W::AbstractNoiseProcess, dt;
+        W::Union{SimpleNoiseProcess, BoxWedgeTail}, dt;
         t0 = W.t[1],
         erase_sol = true,
         setup_next = false
@@ -229,17 +229,34 @@ function DiffEqBase.reinit!(
     return nothing
 end
 
-function Base.reverse(W::AbstractNoiseProcess)
-    if W isa NoiseGrid
-        if W.Z === nothing
-            backwardnoise = NoiseGrid(reverse(W.t), reverse(W.W))
-        else
-            backwardnoise = NoiseGrid(reverse(W.t), reverse(W.W), reverse(W.Z))
-        end
+function Base.reverse(W::NoiseGrid)
+    if W.Z === nothing
+        return NoiseGrid(reverse(W.t), reverse(W.W))
     else
-        W.save_everystep = false
-        backwardnoise = NoiseWrapper(W, reverse = true)
+        return NoiseGrid(reverse(W.t), reverse(W.W), reverse(W.Z))
     end
-    return backwardnoise
+end
+
+function Base.reverse(
+        W::Union{
+            NoiseProcess, SimpleNoiseProcess, NoiseWrapper, NoiseFunction, NoiseTransport,
+            NoiseApproximation, BoxWedgeTail,
+        }
+    )
+    W.save_everystep = false
+    return NoiseWrapper(W, reverse = true)
 end
 Base.reverse(W::VirtualBrownianTree) = W
+
+for WType in (SimpleNoiseProcess, NoiseFunction, NoiseTransport, VirtualBrownianTree, BoxWedgeTail),
+        PType in (NoiseApproximation, NoiseGrid)
+    @eval function interpolate!(W::$WType, u, p::$PType, t)
+        return invoke(interpolate!, Tuple{$WType, Any, Any, Any}, W, u, p, t)
+    end
+end
+
+for WType in (NoiseProcess, NoiseWrapper), PType in (NoiseApproximation, NoiseGrid)
+    @eval function interpolate!(W::$WType, u, p::$PType, t; reverse = false)
+        return invoke(interpolate!, Tuple{$WType, Any, Any, Any}, W, u, p, t; reverse)
+    end
+end

--- a/src/noise_interfaces/noise_process_interface.jl
+++ b/src/noise_interfaces/noise_process_interface.jl
@@ -651,6 +651,7 @@ end
                 return copy(W.curW), nothing
             end
         else
+            Z0 = Zh = nothing
             if reverse
                 W0, Wh = W.W[i], W.W[i - 1] - W.W[i]
                 if W.Z !== nothing
@@ -770,6 +771,7 @@ end
                 out2 .= W.Z[i]
             end
         else
+            Z0 = Zh = nothing
             if reverse
                 W0, Wh = W.W[i], W.W[i - 1]
                 if W.Z !== nothing

--- a/src/noise_interfaces/simple_noise_process_interface.jl
+++ b/src/noise_interfaces/simple_noise_process_interface.jl
@@ -118,6 +118,7 @@ end
             end
         else
             W0, Wh = W.W[i - 1], W.W[i]
+            Z0 = Zh = nothing
             if W.Z !== nothing
                 Z0, Zh = W.Z[i - 1], W.Z[i]
             end
@@ -204,6 +205,7 @@ end
             end
         else
             W0, Wh = W.W[i - 1], W.W[i]
+            Z0 = Zh = nothing
             if W.Z !== nothing
                 Z0, Zh = W.Z[i - 1], W.Z[i]
             end

--- a/src/noise_interfaces/virtual_brownian_tree_interface.jl
+++ b/src/noise_interfaces/virtual_brownian_tree_interface.jl
@@ -270,6 +270,7 @@ function search_VBT(
 
     # create a buffer
     W0tmp, W1tmp = copy(W0), copy(W1)
+    Z0tmp = Z1tmp = nothing
     if Z0 !== nothing
         Z0tmp, Z1tmp = copy(Z0), copy(Z1)
     end

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,5 +1,3 @@
-isinplace(W::AbstractNoiseProcess{T, N, S, inplace}) where {T, N, S, inplace} = inplace
-
 """
 ```julia
 NoiseProcess{T, N, Tt, T2, T3, ZType, F, F2, inplace, S1, S2, RSWM, C, RNGType} <:
@@ -1703,3 +1701,11 @@ function BoxWedgeTail!(
     )
     return BoxWedgeTail{true}(t0, W0, Z0, dist, bridge; kwargs...)
 end
+
+const NoiseProcessType = Union{
+    NoiseProcess, SimpleNoiseProcess, NoiseWrapper, NoiseFunction, NoiseTransport,
+    NoiseGrid, NoiseApproximation, VirtualBrownianTree, BoxWedgeTail,
+}
+
+@inline _isinplace(::Type{<:AbstractNoiseProcess{T, N, S, inplace}}) where {T, N, S, inplace} = inplace
+@inline isinplace(W::NoiseProcessType) = _isinplace(typeof(W))

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -8,23 +8,6 @@ using Optim, ReverseDiff
 
 run_qa(
     DiffEqNoiseProcess;
-    # Ambiguities and piracies are genuine findings tracked in
-    # https://github.com/SciML/DiffEqNoiseProcess.jl/issues/283
-    aqua_broken = (:ambiguities, :piracies),
-    # On Julia >= 1.12, JET typo-mode (report_package) flags 27 pre-existing
-    # "local variable may be undefined" reports, all of the same shape: a value
-    # assigned inside one `X !== nothing` / `offset !== nothing` guard and used
-    # inside a *second* branch protected by the identical (never-invalidated)
-    # guard, in interpolate! / generate_boxes / the VBT bridge. JET's
-    # intraprocedural undef analysis can't prove the guards are correlated, so
-    # they are false positives at runtime but genuine latent code patterns. The
-    # previous hand-rolled qa explicitly skipped report_package (only report_opt
-    # on a few functions), so these were never surfaced; they reproduce
-    # byte-identically on unmodified master. On Julia <= 1.11 JET finds 0 reports
-    # (the analysis is version-specific), so jet_broken is gated to avoid an
-    # Unexpected Pass there.
-    # Tracked in https://github.com/SciML/DiffEqNoiseProcess.jl/issues/283
-    jet_broken = VERSION >= v"1.12",
     ei_kwargs = (;
         # @.. (FastBroadcast) and DEIntegrator (SciMLBase) are re-exported by
         # DiffEqBase but owned elsewhere; imported via DiffEqBase by convention.


### PR DESCRIPTION
## What changed

Removes the DiffEqNoiseProcess source-level strict-QA exemptions by resolving the interpolation dispatch ambiguities, narrowing extensions of external generic functions to the package's concrete noise types, and making JET-visible initialization explicit. This branch is rebased on the merged standard-library compat update, so `run_qa` now has no Aqua or JET broken configuration.

The ambiguity resolver methods select the process-first interpolation API when a noise process is also an `AbstractArray`; previously that call shape was ambiguous with the in-place `NoiseGrid` and `NoiseApproximation` overloads.

Ignore until reviewed by @ChrisRackauckas.

## Verification

Before this change on `e158cb4` with the source-level exclusions removed:

```
GROUP=QA julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
QA/qa.jl | 14 passed, 3 failed, 1 broken
```

The failures were Aqua method ambiguities, Aqua piracy, and 27 JET definite-assignment reports. On the rebased branch:

```
GROUP=QA julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
QA/qa.jl | 21 passed, 21 total
Testing DiffEqNoiseProcess tests passed
```

```
GROUP=Core julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
Core/BWT_test.jl | 88 passed
Core/VBT_test.jl | 31 passed
Core/bridge_test.jl | 92 passed
Core/copy_noise_test.jl | 81 passed
Core/noise_process_interface.jl | 32 passed
Core/reversal_test.jl | 54 passed
Testing DiffEqNoiseProcess tests passed
```

Also passed: Runic, `typos --format brief` over the diff, and `git diff --check`.

No docs build was run because this PR does not modify documentation or public API documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/019f4028-d2ae-7a12-aff0-7d996bd9c791