### PR TITLE
Format for Runic v1.10

### DIFF
--- a/test/BWT_test.jl
+++ b/test/BWT_test.jl
@@ -262,9 +262,9 @@
 
     samples = [
         DiffEqNoiseProcess.sample_distribution(
-                W, one(W.dt), nothing, nothing,
-                nothing, W.rng
-            ) for i in 1:100_000
+            W, one(W.dt), nothing, nothing,
+            nothing, W.rng
+        ) for i in 1:100_000
     ]
 
     dW1 = getindex.(getindex.(samples, 1), 1)


### PR DESCRIPTION
## What changed and why

Runic v1.10.0 changed multiline generator-element indentation. This PR applies the formatter output required by that release; it contains no behavioral, dependency, or public-API changes.

**Ignore this PR until it has been reviewed by @ChrisRackauckas.**

## Verification

Failing before formatting at `30b6db1aeff8`:

```console
$ ~/.juliaup/bin/julia +release --startup-file=no --project=@runic -m Runic --check .
[exit 1]
```

Passing after formatting:

```console
$ ~/.juliaup/bin/julia +release --startup-file=no --project=@runic -m Runic --check .
[exit 0]
$ git diff HEAD^ --check
[exit 0]
$ typos test/BWT_test.jl
[exit 0]
$ GROUP=QA ~/.juliaup/bin/julia +release --startup-file=no --project -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA/qa.jl      |   21     21  5m41.5s
Testing DiffEqNoiseProcess tests passed
$ GROUP=All ~/.juliaup/bin/julia +release --startup-file=no --project -e 'using Pkg; Pkg.test()'
Core/pcn_test.jl | 59 pass, 59 total
Core/reinit_test.jl | 42 pass, 42 total
Core/reversal_test.jl | 54 pass, 54 total
Core/savestep_test.jl | 100 pass, 100 total
Core/sde_noise_wrapper.jl | 22 pass, 22 total
Testing DiffEqNoiseProcess tests passed
```

The Ubuntu Core CI job hit a pre-existing exact-floating-point assertion in
`test/noise_approximation.jl`, outside this PR's `test/BWT_test.jl` diff. A deterministic
seed fails on clean base by one ulp; the independent fix and failing-before/passing-after
evidence are in https://github.com/SciML/DiffEqNoiseProcess.jl/pull/325.

## Not verified

- Docs were not built because no docstring, `docs/`, or public API changed.
- One Core CI path remains blocked on the independent clean-base assertion fixed by https://github.com/SciML/DiffEqNoiseProcess.jl/pull/325.
- GPU, downstream, and allowed-to-fail jobs were not run locally.

## Reviewer note

This is a mechanical Runic-only change; the test diff should be reviewed as formatting output.

🤖 Generated with Codex CLI 0.151.0 (model: unknown; session: local session ID 01a04fa1-cfe0-7260-b416-72fe8a15d17d)
