### PR TITLE
Make NoiseApproximation endpoint check deterministic

### DIFF
--- a/test/noise_approximation.jl
+++ b/test/noise_approximation.jl
@@ -5,7 +5,7 @@
     import SDEProblemLibrary: prob_sde_linear, prob_sde_2Dlinear
 
     prob = prob_sde_linear
-    integrator = init(prob, EM(), dt = 0.01)
+    integrator = init(prob, EM(), dt = 0.01, seed = 2203)
 
     W = NoiseApproximation(integrator)
 
@@ -17,7 +17,8 @@
     accept_step!(W, dt, nothing, nothing)
     @test W.curW == 0.5 + dWold
     @test W.curt == dt
-    @test W.curW + W.dW == W.u[end]
+    # Some endpoints have no Float64 increment that reconstructs them exactly.
+    @test abs(W.curW + W.dW - W.u[end]) <= eps(W.u[end])
     @test W.curW == W.u[11]
 
     W = NoiseApproximation(integrator)


### PR DESCRIPTION
## Summary

Ignore this PR until it has been reviewed by @ChrisRackauckas.

Make the `NoiseApproximation` endpoint regression deterministic and check the endpoint reconstruction to the tightest valid `Float64` bound. The prior exact-equality assertion is not satisfiable for every trajectory: for the seeded failing case, no representable `Float64` increment sums with `curW` to the stored endpoint exactly.

The invalid exact assertion dates to the original NoiseApproximation test in https://github.com/SciML/DiffEqNoiseProcess.jl/commit/1e2835136fa9e24624820ee07d71c4128187f796. This failure therefore predates and is independent of the formatting-only change in https://github.com/SciML/DiffEqNoiseProcess.jl/pull/324.

For the deterministic failing trajectory:

- `curW = 0.505344169405949`
- endpoint `= 0.2403164608981335`
- stored increment `= -0.26502770850781543`
- `eps(endpoint) = 2.7755575615628914e-17`

`prevfloat(dW)`, `dW`, and `nextfloat(dW)` reconstruct respectively one ULP below, one ULP above, and three ULP above the endpoint. There is no exact representable increment, so this uses an explicit one-ULP bound rather than broad approximate equality.

## Verification

Failing before the fix, with Julia 1.12.7 and the CI dependency versions (DiffEqBase 7.20.0, StochasticDiffEq 7.1.5, SDEProblemLibrary 1.2.4):

```console
$ julia +1.12.7 --project=../noise-repro-env -e 'using Test, DiffEqNoiseProcess, DiffEqBase, StochasticDiffEq, SDEProblemLibrary; include("test/noise_approximation.jl")'
Expression: W.curW + W.dW == W.u[end]
 Evaluated: 0.24031646089813352 == 0.2403164608981335
Test Summary:      | Pass  Fail  Total
NoiseApproximation |    5     1      6
```

Passing after the fix, using the same command and environment:

```console
Test Summary:      | Pass  Total
NoiseApproximation |    6      6
```

Full targeted validation:

```console
$ GROUP=Core julia +1.12.7 --project -e 'using Pkg; Pkg.test()'
Core/RSwM_correctness_test.jl | 1282617  1282617
Core/noise_approximation.jl   |       6        6
Testing DiffEqNoiseProcess tests passed

$ GROUP=QA julia +1.12.7 --project -e 'using Pkg; Pkg.test()'
QA/qa.jl | 21  21
Testing DiffEqNoiseProcess tests passed

$ julia +1.12.7 -e 'using Runic; exit(Runic.main(["--check", "test/noise_approximation.jl"]))'
# exit 0

$ git diff --name-only -z upstream/master...HEAD | xargs -0 typos
# exit 0

$ git diff --check upstream/master...HEAD
# exit 0
```

Whole-repository Runic still reports only the pre-existing `test/BWT_test.jl` drift addressed separately by https://github.com/SciML/DiffEqNoiseProcess.jl/pull/324. Documentation was not built because this changes only a private test and does not touch docs, docstrings, or public API. GPU, downstream, Julia pre-release, and downgrade jobs were not run locally.

Reviewer judgment: the one-ULP endpoint bound is intentional and minimal, based on inspecting the adjacent representable values; it is not a generic tolerance increase.

🤖 Generated with Codex CLI 0.151.0 (model: unknown; session: local session ID 01a04fa1-cfe0-7260-b416-72fe8a15d17d)
