### PR TITLE
Snap NoiseApproximation endpoint on accept_step!

### DIFF
--- a/src/noise_interfaces/noise_approximation_interface.jl
+++ b/src/noise_interfaces/noise_approximation_interface.jl
@@ -36,17 +36,20 @@ function calculate_step!(W::NoiseApproximation, dt, u, p)
 end
 
 function accept_step!(W::NoiseApproximation, dt, u, p, setup_next = true)
+    # Snap onto the source solution values that `calculate_step!` prepared as the
+    # step target. Accumulating `curW += dW` can miss that endpoint by 1 ULP
+    # because `curW + (target - curW)` is not always exactly `target` in Float64.
     if isinplace(W)
-        W.curW .+= W.dW
+        W.curW .= W.source1.u
     else
-        W.curW += W.dW
+        W.curW = copy(W.source1.u)
     end
-    W.curt += W.dt
+    W.curt = W.source1.t
     if W.Z !== nothing
         if isinplace(W)
-            W.curZ .+= W.dZ
+            W.curZ .= W.source2.u
         else
-            W.curZ += W.dZ
+            W.curZ = copy(W.source2.u)
         end
     end
 

--- a/test/noise_approximation.jl
+++ b/test/noise_approximation.jl
@@ -5,7 +5,7 @@
     import SDEProblemLibrary: prob_sde_linear, prob_sde_2Dlinear
 
     prob = prob_sde_linear
-    integrator = init(prob, EM(), dt = 0.01)
+    integrator = init(prob, EM(), dt = 0.01, seed = 2203)
 
     W = NoiseApproximation(integrator)
 
@@ -17,8 +17,14 @@
     accept_step!(W, dt, nothing, nothing)
     @test W.curW == 0.5 + dWold
     @test W.curt == dt
-    @test W.curW + W.dW == W.u[end]
     @test W.curW == W.u[11]
+    # Pending step targets the source endpoint; accepting snaps onto it exactly.
+    # (For this seed, no Float64 dW satisfies curW + dW == u[end] before the snap.)
+    target = W.u[end]
+    @test W.source1.u == target
+    accept_step!(W, dt, nothing, nothing, false)
+    @test W.curW == target
+    @test W.curt == 2dt
 
     W = NoiseApproximation(integrator)
     for i in 1:10


### PR DESCRIPTION
## Summary

Supersedes https://github.com/SciML/DiffEqNoiseProcess.jl/pull/325.

The failing `W.curW + W.dW == W.u[end]` check is not a bad assertion tolerance: for some trajectories no representable `Float64` increment reconstructs the source endpoint (`curW + (target - curW)` is not always `target`). Loosening the test to one ULP papers over that. The real fix is to **snap** `curW`/`curZ`/`curt` onto the prepared source integrator state in `accept_step!` instead of accumulating `+= dW` / `+= dt`.

- `accept_step!(::NoiseApproximation)` copies `source1.u` / `source2.u` and sets `curt = source1.t`
- Test uses the previously failing seed (`2203`) and checks that accepting the pending step lands exactly on `W.u[end]`

## Test plan

- [x] `include("test/noise_approximation.jl")` — 8/8 pass with seed 2203
- [ ] CI Core / QA groups


Made with [Cursor](https://cursor.com)