### PR TITLE
Preserve array backends in Wiener sampling

### DIFF
--- a/src/wiener.jl
+++ b/src/wiener.jl
@@ -25,8 +25,11 @@ Generate an array of random numbers from the standard normal distribution, match
 # Returns
 An array of random numbers from the standard normal distribution with the same size as proto
 """
-@inline function wiener_randn(rng::AbstractRNG, proto::AbstractArray{T}) where {T <: Number}
+@inline function wiener_randn(rng::AbstractRNG, proto::Array{T}) where {T <: Number}
     return randn(rng, T, size(proto))
+end
+@inline function wiener_randn(rng::AbstractRNG, proto::AbstractArray{T}) where {T <: Number}
+    return randn!(rng, similar(proto, T, size(proto)))
 end
 """
     wiener_randn(rng::AbstractRNG, proto::T) where {T <: StaticArraysCore.SArray}

--- a/test/wiener_backend_test.jl
+++ b/test/wiener_backend_test.jl
@@ -1,0 +1,28 @@
+using DiffEqNoiseProcess, Random, Test
+
+struct BackendArray{T, N} <: AbstractArray{T, N}
+    data::Array{T, N}
+end
+
+Base.size(array::BackendArray) = size(array.data)
+Base.getindex(array::BackendArray, index::Int) = getindex(array.data, index)
+Base.IndexStyle(::Type{<:BackendArray}) = IndexLinear()
+const backend_randn_called = Ref(false)
+function Base.similar(::BackendArray, ::Type{T}, dimensions::Dims) where {T}
+    return BackendArray(Array{T}(undef, dimensions))
+end
+function Random.randn!(rng::AbstractRNG, array::BackendArray)
+    backend_randn_called[] = true
+    randn!(rng, array.data)
+    return array
+end
+
+@testset "Wiener samples preserve the prototype backend" begin
+    seed = UInt64(0x5eed)
+    prototype = BackendArray(zeros(Float32, 2, 3))
+    sample = DiffEqNoiseProcess.wiener_randn(Xoshiro(seed), prototype)
+
+    @test backend_randn_called[]
+    @test sample isa BackendArray
+    @test sample.data == randn(Xoshiro(seed), Float32, size(prototype))
+end


### PR DESCRIPTION
Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Out-of-place Wiener sampling treated every `AbstractArray` prototype like a host `Array`, so a Tracker-wrapped GPU prototype produced a host `Matrix`. Brownian-bridge interpolation then attempted to broadcast that host matrix with a device matrix, which GPUCompiler rejects in the seeded DiffEqFlux SOSRI test.

The generic array path now allocates `similar(proto, ...)` and fills that destination through `Random.randn!(rng, destination)`. This preserves the prototype backend and lets the array package select its own random implementation. The direct `Array` method remains unchanged, and no public/exported name changes.

For CPU RNGs such as `Xoshiro` and `StableRNG`, GPUArrays' destination specialization generates the passed RNG's values on the host and copies them to the GPU array. A GPUArrays/CUDA RNG instead selects its RNG-specific device implementation through the same call.

The overly broad dispatch originated when `Array` was expanded to `AbstractArray` for complex-array correctness in https://github.com/SciML/DiffEqNoiseProcess.jl/pull/157.

## Failing before / passing after

The revised regression test provides a backend with a specialized `Random.randn!` method and records whether that method was called. On unmodified `master`, the same test showed that backend dispatch was bypassed and a host matrix was returned:

```text
Expression: backend_randn_called[]
Expression: sample isa BackendArray
 Evaluated: Float32[...] isa BackendArray
Expression: sample.data == randn(...)
 type Array has no field data
Test Summary:                                 | Fail  Error  Total
Wiener samples preserve the prototype backend |    2      1      3
ERROR: Some tests did not pass: 0 passed, 2 failed, 1 errored, 0 broken.
```

With this implementation, the identical test passes:

```text
Test Summary:                                 | Pass  Total
Wiener samples preserve the prototype backend |    3      3
```

## Local verification

```sh
GROUP=Core JULIA_NUM_PRECOMPILE_TASKS=1 /home/crackauc/.juliaup/bin/julia +1.10 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
```

```text
Core/wiener_backend_test.jl | 3 pass | 3 total
Testing DiffEqNoiseProcess tests passed
```

```sh
GROUP=QA JULIA_NUM_PRECOMPILE_TASKS=1 /home/crackauc/.juliaup/bin/julia +1.10 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
```

```text
QA/qa.jl | 19 pass | 19 total
Testing DiffEqNoiseProcess tests passed
```

A local `JLArray` probe checked the GPUArrays dispatch with both `Xoshiro` and `StableRNG`. For both RNGs, `which(Random.randn!, ...)` selected GPUArrays' `randn!(rng::AbstractRNG, ::AbstractGPUArray)` method at `src/host/random.jl:605`; all four backend-type and exact-value assertions passed, and the process exited 0.

```sh
/home/crackauc/.juliaup/bin/julia +release --startup-file=no -m Runic --check src/wiener.jl test/wiener_backend_test.jl
typos src/wiener.jl test/wiener_backend_test.jl
git diff --check
```

All three formatting, spelling, and diff checks exited 0 with no output.

## Hosted verification

All 16 jobs on the exact owner revision are green: Core on Julia release, LTS, and pre; QA; downgrade; docs; formatting; spelling; package detection; three OrdinaryDiffEq downstream groups; and three SciMLSensitivity downstream groups.

The exact owner revision was then pinned into the DiffEqFlux CUDA test environment. Its hosted V100 job resolved DiffEqNoiseProcess `#8fbbcb1`, StableRNGs 1.0.4, and GPUArrays 11.5.14, then passed all 29 CUDA assertions:

```text
Test Summary: | Pass  Total     Time
CUDA          |   29     29  7m56.7s
Testing DiffEqFlux tests passed
```

Passing V100 job: https://github.com/SciML/DiffEqFlux.jl/actions/runs/33970922341/job/101319166032.

The docs build was not run locally because this changes no docs, docstrings, or public API; the hosted docs build passed.

## Links

- Exact owner revision: https://github.com/SciML/DiffEqNoiseProcess.jl/commit/8fbbcb12d5547c2d9dd563cdfee4c13d52e1067c
- Passing owner CI: https://github.com/SciML/DiffEqNoiseProcess.jl/actions/runs/33961497704
- Passing downstream CI: https://github.com/SciML/DiffEqNoiseProcess.jl/actions/runs/33961497631
- Original DiffEqFlux CUDA failure: https://github.com/SciML/DiffEqFlux.jl/actions/runs/33463611417/job/99718809319
- Exact-stack V100 validation: https://github.com/SciML/DiffEqFlux.jl/pull/1078
- Passing exact-stack V100 job: https://github.com/SciML/DiffEqFlux.jl/actions/runs/33970922341/job/101319166032
- Originating dispatch change: https://github.com/SciML/DiffEqNoiseProcess.jl/pull/157

🤖 Generated with Codex CLI 0.151.0 (model: gpt-5.6-sol; session: local session ID 01a0598f-11b9-72d1-91d9-b2fbb186557d)
