### PR TITLE
Preserve backend dispatch for Wiener array sampling

### DIFF
--- a/src/wiener.jl
+++ b/src/wiener.jl
@@ -25,8 +25,11 @@ Generate an array of random numbers from the standard normal distribution, match
 # Returns
 An array of random numbers from the standard normal distribution with the same size as proto
 """
-@inline function wiener_randn(rng::AbstractRNG, proto::AbstractArray{T}) where {T <: Number}
+@inline function wiener_randn(rng::AbstractRNG, proto::Array{T}) where {T <: Number}
     return randn(rng, T, size(proto))
+end
+@inline function wiener_randn(rng::AbstractRNG, proto::AbstractArray{T}) where {T <: Number}
+    return randn!(rng, similar(proto, T, size(proto)))
 end
 """
     wiener_randn(rng::AbstractRNG, proto::T) where {T <: StaticArraysCore.SArray}

--- a/test/wiener_backend_test.jl
+++ b/test/wiener_backend_test.jl
@@ -1,0 +1,28 @@
+using DiffEqNoiseProcess, Random, Test
+
+struct BackendArray{T, N} <: AbstractArray{T, N}
+    data::Array{T, N}
+end
+
+Base.size(array::BackendArray) = size(array.data)
+Base.getindex(array::BackendArray, index::Int) = getindex(array.data, index)
+Base.IndexStyle(::Type{<:BackendArray}) = IndexLinear()
+const backend_randn_called = Ref(false)
+function Base.similar(::BackendArray, ::Type{T}, dimensions::Dims) where {T}
+    return BackendArray(Array{T}(undef, dimensions))
+end
+function Random.randn!(rng::AbstractRNG, array::BackendArray)
+    backend_randn_called[] = true
+    randn!(rng, array.data)
+    return array
+end
+
+@testset "Wiener samples preserve the prototype backend" begin
+    seed = UInt64(0x5eed)
+    prototype = BackendArray(zeros(Float32, 2, 3))
+    sample = DiffEqNoiseProcess.wiener_randn(Xoshiro(seed), prototype)
+
+    @test backend_randn_called[]
+    @test sample isa BackendArray
+    @test sample.data == randn(Xoshiro(seed), Float32, size(prototype))
+end


### PR DESCRIPTION
Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Out-of-place Wiener sampling currently treats every `AbstractArray` prototype like a dense host `Array`:

```julia
randn(rng, T, size(proto))
```

That loses the prototype's storage backend before array-specific random dispatch can participate. In the original DiffEqFlux CUDA failure, a Tracker-wrapped GPU prototype therefore produced a host `Matrix`, and Brownian-bridge interpolation attempted to broadcast it with a device matrix.

This PR retains the existing method for `Array`, while the generic `AbstractArray` method now allocates `similar(proto, ...)` and calls `Random.randn!(rng, destination)`. The destination type can then select GPUArrays/CUDA or another array backend's implementation while preserving the explicitly supplied RNG. No public/exported name or dependency changes.

## Why this remains needed after PR 328

The earlier draft https://github.com/SciML/DiffEqNoiseProcess.jl/pull/328 was closed without a comment or review exactly one second after the StableRNG DiffEqFlux fix https://github.com/SciML/DiffEqFlux.jl/pull/1075 was merged. The timing suggests it was considered redundant; there is no recorded close reason, so that is an inference.

StableRNGs fixed the flaky DiffEqFlux test by choosing a deterministic trajectory that does not expose the failing adaptive bridge allocation. It did not fix this owner-package behavior: current DiffEqNoiseProcess `master` still returns a host `Matrix` for a non-`Array` prototype and fails the backend-dispatch regression below. No alternative fix has landed.

## Failing before / passing after

The regression defines an `AbstractArray` backend with specialized `similar` and `Random.randn!` methods. It verifies that backend dispatch was called, the returned backend was preserved, and the supplied RNG produced exactly the expected stream.

On clean current `master` at `5158169`:

```text
Expression: backend_randn_called[]
Expression: sample isa BackendArray
 Evaluated: Float32[...] isa BackendArray
Expression: sample.data == randn(...)
 type Array has no field data
Test Summary:                                 | Fail  Error  Total
Wiener samples preserve the prototype backend |    2      1      3
ERROR: Some tests did not pass: 0 passed, 2 failed, 1 errored, 0 broken.
```

With this PR:

```text
Test Summary:                                 | Pass  Total  Time
Wiener samples preserve the prototype backend |    3      3  0.2s
```

## Local verification

```sh
GROUP=Core JULIA_NUM_PRECOMPILE_TASKS=1 /home/crackauc/.juliaup/bin/julia +1.10 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
```

Every Core testset passed, including:

```text
Core/wiener_backend_test.jl | 3 pass | 3 total
Testing DiffEqNoiseProcess tests passed
```

```sh
GROUP=QA JULIA_NUM_PRECOMPILE_TASKS=1 /home/crackauc/.juliaup/bin/julia +1.10 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
```

```text
QA/qa.jl | 19 pass | 19 total
Testing DiffEqNoiseProcess tests passed
```

A local JLArray probe used both `Xoshiro` and `StableRNG`. For each RNG, `which(Random.randn!, ...)` selected GPUArrays' `randn!(rng::AbstractRNG, ::AbstractGPUArray)` method at `src/host/random.jl:605`; all four backend-type and exact-value assertions passed:

```text
Test Summary:                      | Pass  Total  Time
GPUArrays RNG destination dispatch |    4      4  2.6s
```

```sh
/home/crackauc/.juliaup/bin/julia +release --startup-file=no -m Runic --check src/wiener.jl test/wiener_backend_test.jl
typos src/wiener.jl test/wiener_backend_test.jl
git diff --check HEAD^ HEAD
```

All three commands exited 0 with no output.

## Hosted verification

Sixteen of seventeen current-branch checks passed: release/LTS/pre Core, QA, downgrade, docs, Runic, typos, and all six OrdinaryDiffEq/SciMLSensitivity downstream jobs. The sole failure is the newly added Julia x86 Core lane: clean current `master` reproduces its `DivideError` in `split_VBT_seed` with the same `Core/VBT_test.jl | 8 pass, 1 error` result, independent of this PR.

That pre-existing failure was bisected to the original VBT commit. The open 32-bit fix still overflowed `Nt`; adding `Nt = Int64(2)^search_depth + 1` on top of it passed VBT 31/31 and the Brownian Bridge block 80/80. The full reproduction and validation are recorded at https://github.com/SciML/DiffEqNoiseProcess.jl/pull/331#issuecomment-5583559032.

The content-identical earlier backend implementation passed all 16 owner and downstream CI jobs. An exact-pinned DiffEqFlux V100 composition resolved that revision, StableRNGs 1.0.4, and GPUArrays 11.5.14, then passed all 29 CUDA assertions in 7m56.7s.

This machine has no functional NVIDIA GPU, so CUDA could not be rerun locally. `GROUP=Everything` was not run locally; the relevant Core and QA groups were run in full. The docs build was not run locally because this PR changes no docs, docstrings, or public API; hosted docs CI passed.

## Links

- Current draft PR CI: https://github.com/SciML/DiffEqNoiseProcess.jl/actions/runs/34210765126
- Current downstream CI: https://github.com/SciML/DiffEqNoiseProcess.jl/actions/runs/34210764939
- Pre-existing x86 failure: https://github.com/SciML/DiffEqNoiseProcess.jl/actions/runs/34210765126/job/102011050547
- Verified x86 investigation: https://github.com/SciML/DiffEqNoiseProcess.jl/pull/331#issuecomment-5583559032
- Superseded closed PR: https://github.com/SciML/DiffEqNoiseProcess.jl/pull/328
- StableRNG test fix: https://github.com/SciML/DiffEqFlux.jl/pull/1075
- Original DiffEqFlux CUDA failure: https://github.com/SciML/DiffEqFlux.jl/actions/runs/33463611417/job/99718809319
- Previous passing owner CI: https://github.com/SciML/DiffEqNoiseProcess.jl/actions/runs/33961497704
- Previous passing downstream CI: https://github.com/SciML/DiffEqNoiseProcess.jl/actions/runs/33961497631
- Previous exact-stack V100 validation: https://github.com/SciML/DiffEqFlux.jl/actions/runs/33970922341/job/101319166032
- Originating `Array` to `AbstractArray` change: https://github.com/SciML/DiffEqNoiseProcess.jl/pull/157

🤖 Generated with Codex CLI 0.151.0 (model: gpt-5.6-sol; session: local session ID 01a0598f-11b9-72d1-91d9-b2fbb186557d)
