### PR TITLE
Release DiffEqNoiseProcess 5.36.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqNoiseProcess"
 uuid = "77a26b50-5914-5dd7-bc55-306e6241c503"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "5.36.2"
+version = "5.36.3"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"


### PR DESCRIPTION
Bumps `DiffEqNoiseProcess` 5.36.2 -> 5.36.3 (patch).

Source files changed since 5.36.2:
- `src/noise_interfaces/virtual_brownian_tree_interface.jl`
- `src/wiener.jl`

Commits:
- Add 32-bit Core CI lane via test_groups.toml (#329)
- Preserve array backends in Wiener sampling (#332)
- Fix VirtualBrownianTree seed split on 32-bit Julia (#331)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
