### PR TITLE
Add AirspeedVelocity benchmarking CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,29 @@
+name: Benchmark this PR
+
+on:
+  pull_request:
+    branches: [master]
+    paths-ignore: ['docs/**']
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["1", "lts"]
+    env:
+      # Force consistent Julia depot path for self-hosted runners
+      JULIA_DEPOT_PATH: ~/.julia
+    steps:
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+        with:
+          julia-version: ${{ matrix.version }}
+          script: "benchmark/benchmarks.jl"
+          extra-pkgs: "DiffEqBase"
+          job-summary: true

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,52 @@
+using DiffEqNoiseProcess, DiffEqBase, BenchmarkTools
+
+const SUITE = BenchmarkGroup()
+
+# =============================================================================
+# Noise process simulation
+# =============================================================================
+
+SUITE["simulate"] = BenchmarkGroup()
+
+W_scalar = WienerProcess(0.0, 0.0, 0.0)
+prob_w = NoiseProblem(W_scalar, (0.0, 1.0); seed = 1234)
+
+W_vec = WienerProcess!(0.0, zeros(10), zeros(10))
+prob_wv = NoiseProblem(W_vec, (0.0, 1.0); seed = 1234)
+
+gbm = GeometricBrownianMotionProcess(0.01, 0.2, 0.0, 1.0, 1.0)
+prob_gbm = NoiseProblem(gbm, (0.0, 1.0); seed = 1234)
+
+ou = OrnsteinUhlenbeckProcess(1.0, 0.0, 0.5, 0.0, 0.0)
+prob_ou = NoiseProblem(ou, (0.0, 1.0); seed = 1234)
+
+SUITE["simulate"]["wiener_scalar"] = @benchmarkable solve($prob_w; dt = 0.001)
+SUITE["simulate"]["wiener_vector"] = @benchmarkable solve($prob_wv; dt = 0.001)
+SUITE["simulate"]["geometric_brownian"] = @benchmarkable solve($prob_gbm; dt = 0.001)
+SUITE["simulate"]["ornstein_uhlenbeck"] = @benchmarkable solve($prob_ou; dt = 0.001)
+
+# =============================================================================
+# Bridge processes
+# =============================================================================
+
+SUITE["bridge"] = BenchmarkGroup()
+
+Wb = BrownianBridge(0.0, 1.0, 0.0, 1.0)
+prob_wb = NoiseProblem(Wb, (0.0, 1.0); seed = 1234)
+
+gbmb = GeometricBrownianBridge(0.01, 0.2, 0.0, 1.0, 1.0, 1.5)
+prob_gbmb = NoiseProblem(gbmb, (0.0, 1.0); seed = 1234)
+
+SUITE["bridge"]["brownian"] = @benchmarkable solve($prob_wb; dt = 0.001)
+SUITE["bridge"]["geometric_brownian"] = @benchmarkable solve($prob_gbmb; dt = 0.001)
+
+# =============================================================================
+# Ensemble simulation
+# =============================================================================
+
+SUITE["ensemble"] = BenchmarkGroup()
+
+eprob = EnsembleProblem(prob_w)
+SUITE["ensemble"]["trajectories_100"] = @benchmarkable solve(
+    $eprob; dt = 0.01, trajectories = 100
+)


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/benchmark.yml` running AirspeedVelocity on pull requests (Julia `1` and `lts`, 30 min timeout), following the OrdinaryDiffEq.jl setup.
- Adds `benchmark/benchmarks.jl` with a small `SUITE` covering representative workloads for this package.

The suite was verified locally in a fresh environment: it loads and all benchmarks run in ~31s.

#### Test plan

- [x] `run(SUITE)` locally: all benchmarks pass (~31s)
- [x] Runic formatting clean on `benchmark/benchmarks.jl`
- [ ] \"Benchmark this PR\" workflow triggers and completes on this PR

🤖 Generated with [Devin](https://devin.ai) (harness: devin 3000.10.21, model: SWE-2 High)
Session: local transcript /home/crackauc/sandbox/tmp_20260911_112052_59120/history_6a789c0b69c64ca3.md